### PR TITLE
Correct compile warnings.

### DIFF
--- a/Sources/API/Display/TargetProviders/input_device_provider.h
+++ b/Sources/API/Display/TargetProviders/input_device_provider.h
@@ -73,10 +73,10 @@ public:
 	virtual bool supports_keyid_mapping() const { return false; }
 
 	/// \brief Returns a generic string name for the specified key code.
-	virtual std::string keyid_to_string(int keycode) const { return std::string(); }
+	virtual std::string keyid_to_string(int /* keycode */) const { return std::string(); }
 
 	/// \brief Returns the key code for the specified generic string key name.
-	virtual int string_to_keyid(const std::string &str) const { return 0; }
+	virtual int string_to_keyid(const std::string &/* str */) const { return 0; }
 
 	/// \brief Returns true if the passed key code is down for this device.
 	/** <p>See keys.h for list of key codes.</p>*/
@@ -98,7 +98,7 @@ public:
 
 	/// \brief Returns the current position of a joystick hat.
 	/// \return Hat direction in degrees (0-360), or -1 if the hat is centered.
-	virtual int get_hat(int index) const { return -1; }
+	virtual int get_hat(int /* index */) const { return -1; }
 
 	/// \brief Returns the number of buttons available on this device.
 	/** <p>If used on a keyboard, this function returns -1.</p>*/

--- a/Sources/API/GUI/gui_message.h
+++ b/Sources/API/GUI/gui_message.h
@@ -47,7 +47,7 @@ class CL_API_GUI GUIMessage
 /// \{
 public:
 	/// \brief Constructs a GUI message.
-	GUIMessage() : consumed(false), target(0) { }
+GUIMessage() : target(0), consumed(false) { }
 	virtual ~GUIMessage() { }
 /// \}
 

--- a/Sources/API/Sound/SoundProviders/soundprovider_session.h
+++ b/Sources/API/Sound/SoundProviders/soundprovider_session.h
@@ -79,7 +79,7 @@ public:
 	/// \brief Enable/disable session looping.
 	/** <p>If this function returns false (default), the clanSound mixer will manually
 	    try to simulate looping by setting the position to 0 when eof is encountered.</p>*/
-	virtual bool set_looping(bool loop) { return false; }
+	virtual bool set_looping(bool /* loop */) { return false; }
 
 	/// \brief Returns true if no more input data is available.
 	/** \return True if end of input data. False otherwise.*/


### PR DESCRIPTION
Some from unused variables (by commenting the variable name) in function definition, some others by re-ordering member constructor call to match class definition.

The aim is to reduce warning message while compiling application that include clanlib's headers, and allow compiling applications with -Werror.

It do not change the behavior of clanlib, and do not remove any information (that's why arguments was commented and not removed).
