### PR TITLE
Update btSoftBodyHelpers.cpp

### DIFF
--- a/Sources/Physics3D/Bullet/BulletSoftBody/btSoftBodyHelpers.cpp
+++ b/Sources/Physics3D/Bullet/BulletSoftBody/btSoftBodyHelpers.cpp
@@ -912,9 +912,9 @@ btSoftBody*		btSoftBodyHelpers::CreateFromConvexHull(btSoftBodyWorldInfo& worldI
 		&hres.m_OutputVertices[0],0);
 	for(int i=0;i<(int)hres.mNumFaces;++i)
 	{
-		const int idx[]={	hres.m_Indices[i*3+0],
-			hres.m_Indices[i*3+1],
-			hres.m_Indices[i*3+2]};
+		const int idx[]={	(int)hres.m_Indices[i*3+0],
+			(int)hres.m_Indices[i*3+1],
+			(int)hres.m_Indices[i*3+2]};
 		if(idx[0]<idx[1]) psb->appendLink(	idx[0],idx[1]);
 		if(idx[1]<idx[2]) psb->appendLink(	idx[1],idx[2]);
 		if(idx[2]<idx[0]) psb->appendLink(	idx[2],idx[0]);


### PR DESCRIPTION
Fix clang compiler error

error: non-constant-expression cannot be narrowed from type 'unsigned int' to 'int' in initializer list [-Wc++11-narrowing]
note: override this message by inserting an explicit cast -> done
