### PR TITLE
Update pixel_buffer_lock.h

### DIFF
--- a/Sources/API/Display/Image/pixel_buffer_lock.h
+++ b/Sources/API/Display/Image/pixel_buffer_lock.h
@@ -31,6 +31,7 @@
 
 #include "../api_display.h"
 #include <memory>
+#include "../../Core/System/exception.h"
 #include "../../Core/Math/vec2.h"
 #include "../../Core/Math/vec3.h"
 #include "../../Core/Math/vec4.h"


### PR DESCRIPTION
fix undeclared identifier

/usr/local/include/ClanLib-3.0/ClanLib/Display/Image/pixel_buffer_lock.h:119:11: error: use of undeclared identifier 'Exception'
throw Exception("Incorrect PixelBufferLock constructor called with a GPU pixelbuffer");
