### PR TITLE
Remove annoying 'ignored qualifier' compiler warning on the Display API.

### DIFF
--- a/Sources/API/Display/Render/graphic_context.h
+++ b/Sources/API/Display/Render/graphic_context.h
@@ -345,7 +345,7 @@ public:
 	/// \brief Returns the provider for this graphic context.
 	GraphicContextProvider *get_provider();
 
-	const GraphicContextProvider * const get_provider() const;
+	const GraphicContextProvider * get_provider() const;
 
 /// \}
 /// \name Operations

--- a/Sources/Display/Render/graphic_context.cpp
+++ b/Sources/Display/Render/graphic_context.cpp
@@ -192,7 +192,7 @@ GraphicContextProvider *GraphicContext::get_provider()
 		return 0;
 }
 
-const GraphicContextProvider * const GraphicContext::get_provider() const
+const GraphicContextProvider * GraphicContext::get_provider() const
 {
 	if (impl)
 		return impl->graphic_screen->get_provider();


### PR DESCRIPTION
I brought this up before but apparently it didn't hold ground because it's was just a small warning. Now it's here because it's annoying when warnings from this header file make up 90% of the compiler warnings on my project and make it harder to find bugs in my code.

EDIT: My wording was horrible. I'm a horrible person.
