### PR TITLE
Build infrastructure is broken

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -823,6 +823,7 @@ AC_CONFIG_FILES([
 		Examples/Makefile
 		Examples/Makefile.conf
 		Setup/Makefile
+		Sources/Database
 		Sources/API/Makefile
 		Sources/App/Makefile
 		Sources/Makefile


### PR DESCRIPTION
With current master I cannot reconfigure:

```
./autogen.sh
Generating ./configure script, this may take a while...
Running aclocal, automake and autoconf...
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
Sources/Makefile.am:3: required directory Sources/Database does not exist
Sources/Makefile.am:3: required directory Sources/GUI does not exist
Sources/Makefile.am:3: required directory Sources/CSSLayout does not exist
Sources/Makefile.am:3: required directory Sources/SWRender does not exist
Sources/Makefile.am:3: required directory Sources/Physics2D does not exist
Sources/Makefile.am:3: required directory Sources/Physics3D does not exist
Sources/Makefile.am:3: required directory Sources/GameIDE does not exist
Sources/Makefile.am:3: required directory Sources/Compute does not exist
Sources/Makefile.am:3: required directory Sources/Sqlite does not exist
configure.ac:670: required file `Sources/Database/Makefile.in' not found
configure.ac:674: required file `Sources/Sqlite/Makefile.in' not found
configure.ac:682: required file `Sources/GUI/Makefile.in' not found
configure.ac:686: required file `Sources/CSSLayout/Makefile.in' not found
configure.ac:689: required file `Sources/SWRender/Makefile.in' not found
configure.ac:692: required file `Sources/Compute/Makefile.in' not found
configure.ac:696: required file `Sources/Scene3D/Makefile.in' not found
configure.ac:700: required file `Sources/Physics3D/Makefile.in' not found
configure.ac:704: required file `Sources/Physics2D/Makefile.in' not found
configure.ac:708: required file `Sources/GameIDE/Makefile.in' not found
```

```
./configure
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking target system type... x86_64-unknown-linux-gnu
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
...
Checking for debugging and profiling
====================================
checking for debug mode... disabled
checking for profile mode... disabled

checking for maintainer mode... disabled
configure: creating ./config.status
config.status: creating Sources/Core/Makefile
config.status: creating Setup/pkgconfig/clanCore.pc
config.status: creating Sources/Display/Makefile
config.status: creating Setup/pkgconfig/clanDisplay.pc
config.status: error: cannot find input file: `Sources/Sound/Makefile.in'
```

Fix the code please.
Have you heard of travis-ci ?
