### PR TITLE
Update soundoutput_directsound.h

### DIFF
--- a/Sources/Sound/Win32/soundoutput_directsound.h
+++ b/Sources/Sound/Win32/soundoutput_directsound.h
@@ -30,6 +30,10 @@
 #include "../soundoutput_impl.h"
 #include <dsound.h>
 
+#ifdef __MINGW32__
+#define _Pre_null_
+#endif
+
 namespace clan
 {
 


### PR DESCRIPTION
_Pre_null_ coming from dx headers is not defined on mingw
