### PR TITLE
Rename DISABLE_SSE2 to CL_DISABLE_SSE2 to actually allow to disable sse2...

### DIFF
--- a/Sources/Core/Math/mat4.cpp
+++ b/Sources/Core/Math/mat4.cpp
@@ -34,7 +34,7 @@
 #include "API/Core/Math/quaternion.h"
 #include <limits>
 
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 //#include <mmintrin.h> /*Dont need it*/
 #include <emmintrin.h>/*it's included here*/
 #endif
@@ -52,7 +52,7 @@ namespace clan
 template<>
 Mat4<float> Mat4<float>::operator *(const Mat4<float> &mult) const
 {
-#if !defined DISABLE_SSE2 && !defined __MINGW32__ //MinGW's version is flawed.
+#if !defined CL_DISABLE_SSE2 && !defined __MINGW32__ //MinGW's version is flawed.
 	Mat4<float> result;
 	__m128 m1col0 = _mm_loadu_ps(matrix);
 	__m128 m1col1 = _mm_loadu_ps(matrix+4);
@@ -646,7 +646,7 @@ Mat4<Type> &Mat4<Type>::scale_self(Type x, Type y, Type z)
 template<>
 Mat4<float> &Mat4<float>::scale_self(float x, float y, float z)
 {
-#if !defined DISABLE_SSE2
+#if !defined CL_DISABLE_SSE2
 	_mm_storeu_ps(matrix, _mm_mul_ps(_mm_loadu_ps(matrix), _mm_set_ps1(x)));
 	_mm_storeu_ps(matrix+4, _mm_mul_ps(_mm_loadu_ps(matrix+4), _mm_set_ps1(y)));
 	_mm_storeu_ps(matrix+8, _mm_mul_ps(_mm_loadu_ps(matrix+8), _mm_set_ps1(z)));
@@ -688,7 +688,7 @@ Mat4<Type> &Mat4<Type>::translate_self(Type x, Type y, Type z)
 template<>
 Mat4<float> &Mat4<float>::translate_self(float x, float y, float z)
 {
-#if !defined DISABLE_SSE2
+#if !defined CL_DISABLE_SSE2
 	__m128 row0 = _mm_loadu_ps(matrix);
 	__m128 row1 = _mm_loadu_ps(matrix+4);
 	__m128 row2 = _mm_loadu_ps(matrix+8);
@@ -963,7 +963,7 @@ Mat4<Type> &Mat4<Type>::transpose()
 template<>
 Mat4<float> &Mat4<float>::transpose()
 {
-#if !defined DISABLE_SSE2
+#if !defined CL_DISABLE_SSE2
 	__m128 row0 = _mm_loadu_ps(matrix);
 	__m128 row1 = _mm_loadu_ps(matrix + 4);
 	__m128 row2 = _mm_loadu_ps(matrix + 8);
@@ -976,7 +976,7 @@ Mat4<float> &Mat4<float>::transpose()
 	_mm_storeu_ps(matrix + 8, row2);
 	_mm_storeu_ps(matrix + 12, row3);
 #else
-	Type original[16];
+	float original[16];
 	for (int cnt = 0; cnt<16; cnt++)
 		original[cnt] = matrix[cnt];
 

--- a/Sources/Core/System/setup_core.cpp
+++ b/Sources/Core/System/setup_core.cpp
@@ -63,7 +63,7 @@ SetupCore::~SetupCore()
 void SetupCore_Impl::init()
 {
 	ThreadLocalStorage::create_initial_instance();
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	if (!System::detect_cpu_extension(System::sse2))
 	{
 		throw Exception("Sorry, ClanLib 3.0 and higher requires a processor capable of SSE2 instructions. (Update your CPU)");

--- a/Sources/Display/ImageProviders/JPEGLoader/jpeg_rgb_decoder.cpp
+++ b/Sources/Display/ImageProviders/JPEGLoader/jpeg_rgb_decoder.cpp
@@ -32,7 +32,7 @@
 #include "jpeg_loader.h"
 #include "API/Core/System/system.h"
 
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 #ifndef ARM_PLATFORM
 #include <xmmintrin.h>
 #include <emmintrin.h>
@@ -79,7 +79,7 @@ void JPEGRGBDecoder::decode(JPEGMCUDecoder *mcu_decoder)
 		convert_monochrome();
 		break;
 	case JPEGLoader::colorspace_ycrcb:
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 		if (System::detect_cpu_extension(System::sse2))
 			convert_ycrcb_sse();
 		else
@@ -161,7 +161,7 @@ void JPEGRGBDecoder::convert_monochrome()
  *
  */
 
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 #ifndef ARM_PLATFORM
 void JPEGRGBDecoder::convert_ycrcb_sse()
 {
@@ -208,7 +208,7 @@ void JPEGRGBDecoder::convert_ycrcb_sse()
 	}
 }
 #endif
-#endif	//not DISABLE_SSE2
+#endif	//not CL_DISABLE_SSE2
 
 void JPEGRGBDecoder::convert_ycrcb_float()
 {

--- a/Sources/Sound/sound_sse.cpp
+++ b/Sources/Sound/sound_sse.cpp
@@ -31,7 +31,7 @@
 #include <cstdlib>
 #include <cstring>
 
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 #include <emmintrin.h>
 #endif
 
@@ -78,7 +78,7 @@ void SoundSSE::aligned_free(void *ptr)
 
 void SoundSSE::unpack_16bit_stereo(short *input, int size, float *output[2])
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/8)*8;
 
 	__m128i zero = _mm_setzero_si128();
@@ -111,7 +111,7 @@ void SoundSSE::unpack_16bit_stereo(short *input, int size, float *output[2])
 
 void SoundSSE::unpack_16bit_mono(short *input, int size, float *output)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/8)*8;
 
 	__m128i zero = _mm_setzero_si128();
@@ -139,7 +139,7 @@ void SoundSSE::unpack_16bit_mono(short *input, int size, float *output)
 
 void SoundSSE::unpack_8bit_stereo(unsigned char *input, int size, float *output[2])
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/16)*16;
 
 	__m128i zero = _mm_setzero_si128();
@@ -186,7 +186,7 @@ void SoundSSE::unpack_8bit_stereo(unsigned char *input, int size, float *output[
 
 void SoundSSE::unpack_8bit_mono(unsigned char *input, int size, float *output)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/16)*16;
 
 	__m128i zero = _mm_setzero_si128();
@@ -223,7 +223,7 @@ void SoundSSE::unpack_8bit_mono(unsigned char *input, int size, float *output)
 
 void SoundSSE::pack_16bit_stereo(float *input[2], int size, short *output)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 
 	__m128 constant1 = _mm_set1_ps(32767);
@@ -256,7 +256,7 @@ void SoundSSE::pack_16bit_stereo(float *input[2], int size, short *output)
 
 void SoundSSE::pack_float_stereo(float *input[2], int size, float *output)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 
 	for (int i = 0; i < sse_size; i+=4)
@@ -284,7 +284,7 @@ void SoundSSE::pack_float_stereo(float *input[2], int size, float *output)
 
 void SoundSSE::copy_float(float *input, int size, float *output)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 
 	for (int i = 0; i < sse_size; i+=4)
@@ -304,7 +304,7 @@ void SoundSSE::copy_float(float *input, int size, float *output)
 
 void SoundSSE::multiply_float(float *channel, int size, float volume)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 
 	__m128 volume0 = _mm_set1_ps(volume);
@@ -324,7 +324,7 @@ void SoundSSE::multiply_float(float *channel, int size, float volume)
 
 void SoundSSE::set_float(float *channel, int size, float value)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 
 	__m128 value0 = _mm_set1_ps(value);
@@ -342,7 +342,7 @@ void SoundSSE::set_float(float *channel, int size, float value)
 
 void SoundSSE::mix_one_to_one(float *input, int size, float *output, float volume)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 	__m128 volume0 = _mm_set1_ps(volume);
 	for (int i = 0; i < sse_size; i+=4)
@@ -364,7 +364,7 @@ void SoundSSE::mix_one_to_one(float *input, int size, float *output, float volum
 
 void SoundSSE::mix_one_to_many(float *input, int size, float **output, float *volume, int channels)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 	for (int i = 0; i < sse_size; i+=4)
 	{
@@ -393,7 +393,7 @@ void SoundSSE::mix_one_to_many(float *input, int size, float **output, float *vo
 
 void SoundSSE::mix_many_to_one(float **input, float *volume, int channels, int size, float *output)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 	for (int i = 0; i < sse_size; i+=4)
 	{
@@ -424,7 +424,7 @@ void SoundSSE::mix_many_to_one(float **input, float *volume, int channels, int s
 
 void SoundSSE::unpack_float_stereo(float *input, int size, float *output[2])
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/8)*8;
 
 	for (int i = 0; i < sse_size; i+=8)
@@ -452,7 +452,7 @@ void SoundSSE::unpack_float_stereo(float *input, int size, float *output[2])
 
 void SoundSSE::unpack_float_mono(float *input, int size, float *output)
 {
-#ifndef DISABLE_SSE2
+#ifndef CL_DISABLE_SSE2
 	int sse_size = (size/4)*4;
 
 	for (int i = 0; i < sse_size; i+=4)


### PR DESCRIPTION
As configure (conditionally) defines CL_DISABLE_SSE2 this macro should be renamed throughout the code to actually allow to disable sse.
