### PR TITLE
Cleaned up the logger code

### DIFF
--- a/Sources/API/Core/Text/logger.h
+++ b/Sources/API/Core/Text/logger.h
@@ -73,13 +73,15 @@ public:
 	void disable();
 
 	/// \brief Log text.
-	virtual void log(const std::string &type, const std::string &text);
+	virtual void log(const std::string &type, const std::string &text) = 0;
 
 /// \}
 /// \name Implementation
 /// \{
 
-private:
+protected:
+	static StringFormat get_log_string(const std::string &type, const std::string &text);
+
 /// \}
 };
 

--- a/Sources/Core/Text/console_logger.cpp
+++ b/Sources/Core/Text/console_logger.cpp
@@ -58,50 +58,7 @@ ConsoleLogger::~ConsoleLogger()
 
 void ConsoleLogger::log(const std::string &type, const std::string &text)
 {
-	std::string months[] =
-	{
-		"Jan",
-		"Feb",
-		"Mar",
-		"Apr",
-		"May",
-		"Jun",
-		"Jul",
-		"Aug",
-		"Sep",
-		"Oct",
-		"Nov",
-		"Dec"
-	};
-	
-	std::string days[] =
-	{
-		"Sun",
-		"Mon",
-		"Tue",
-		"Wed",
-		"Thu",
-		"Fri",
-		"Sat"
-	};
-
-	// Tue Nov 16 11:34:15 2004 UTC
-	DateTime cur_time = DateTime::get_current_utc_time();
-
-#ifdef WIN32
-	StringFormat format("%1 %2 %3 %4:%5:%6 %7 UTC [%8] %9\r\n");
-#else
-	StringFormat format("%1 %2 %3 %4:%5:%6 %7 UTC [%8] %9\n");
-#endif
-	format.set_arg(1, days[cur_time.get_day_of_week()]);
-	format.set_arg(2, months[cur_time.get_month() - 1]);
-	format.set_arg(3, cur_time.get_day());
-	format.set_arg(4, cur_time.get_hour(), 2);
-	format.set_arg(5, cur_time.get_minutes(), 2);
-	format.set_arg(6, cur_time.get_seconds(), 2);
-	format.set_arg(7, cur_time.get_year());
-	format.set_arg(8, type);
-	format.set_arg(9, text);
+	StringFormat format = get_log_string(type, text);
 
 #ifdef WIN32
 	std::wstring log_line = StringHelp::utf8_to_ucs2(format.get_result());

--- a/Sources/Core/Text/file_logger.cpp
+++ b/Sources/Core/Text/file_logger.cpp
@@ -57,50 +57,7 @@ FileLogger::~FileLogger()
 
 void FileLogger::log(const std::string &type, const std::string &text)
 {
-	std::string months[] =
-	{
-		"Jan",
-		"Feb",
-		"Mar",
-		"Apr",
-		"May",
-		"Jun",
-		"Jul",
-		"Aug",
-		"Sep",
-		"Oct",
-		"Nov",
-		"Dec"
-	};
-	
-	std::string days[] =
-	{
-		"Sun",
-		"Mon",
-		"Tue",
-		"Wed",
-		"Thu",
-		"Fri",
-		"Sat"
-	};
-
-	// Tue Nov 16 11:34:15 CET 2004
-	DateTime cur_time = DateTime::get_current_utc_time();
-
-#ifdef WIN32
-	StringFormat format("%1 %2 %3 %4:%5:%6 %7 UTC [%8] %9\r\n");
-#else
-	StringFormat format("%1 %2 %3 %4:%5:%6 %7 UTC [%8] %9\n");
-#endif
-	format.set_arg(1, days[cur_time.get_day_of_week()]);
-	format.set_arg(2, months[cur_time.get_month() - 1]);
-	format.set_arg(3, cur_time.get_day());
-	format.set_arg(4, cur_time.get_hour(), 2);
-	format.set_arg(5, cur_time.get_minutes(), 2);
-	format.set_arg(6, cur_time.get_seconds(), 2);
-	format.set_arg(7, cur_time.get_year());
-	format.set_arg(8, type);
-	format.set_arg(9, text);
+	StringFormat format = get_log_string(type, text);
 	std::string log_line = StringHelp::text_to_local8(format.get_result());
 
 	file->seek(0, File::seek_end);

--- a/Sources/Core/Text/logger.cpp
+++ b/Sources/Core/Text/logger.cpp
@@ -27,7 +27,9 @@
 */
 
 #include "Core/precomp.h"
+#include "API/Core/System/datetime.h"
 #include "API/Core/Text/logger.h"
+#include "API/Core/Text/string_format.h"
 #include <algorithm>
 
 namespace clan
@@ -71,9 +73,54 @@ void Logger::disable()
 		instances.erase(il);
 }
 
-void Logger::log(const std::string &type, const std::string &text)
+StringFormat Logger::get_log_string(const std::string &type, const std::string &text)
 {
-	throw Exception("Implement me");
+	std::string months[] =
+	{
+		"Jan",
+		"Feb",
+		"Mar",
+		"Apr",
+		"May",
+		"Jun",
+		"Jul",
+		"Aug",
+		"Sep",
+		"Oct",
+		"Nov",
+		"Dec"
+	};
+
+	std::string days[] =
+	{
+		"Sun",
+		"Mon",
+		"Tue",
+		"Wed",
+		"Thu",
+		"Fri",
+		"Sat"
+	};
+
+	// Tue Nov 16 11:34:15 CET 2004
+	DateTime cur_time = DateTime::get_current_utc_time();
+
+#ifdef WIN32
+	StringFormat format("%1 %2 %3 %4:%5:%6 %7 UTC [%8] %9\r\n");
+#else
+	StringFormat format("%1 %2 %3 %4:%5:%6 %7 UTC [%8] %9\n");
+#endif
+	format.set_arg(1, days[cur_time.get_day_of_week()]);
+	format.set_arg(2, months[cur_time.get_month() - 1]);
+	format.set_arg(3, cur_time.get_day());
+	format.set_arg(4, cur_time.get_hour(), 2);
+	format.set_arg(5, cur_time.get_minutes(), 2);
+	format.set_arg(6, cur_time.get_seconds(), 2);
+	format.set_arg(7, cur_time.get_year());
+	format.set_arg(8, type);
+	format.set_arg(9, text);
+
+	return format;
 }
 
 void log_event(const std::string &type, const std::string &text)


### PR DESCRIPTION
I made the logger class pure virtual as it is only used as a base class for other loggers (the log method is not even implemented nor could it be in a good way).

Moreover I removed redundant code for building the log string and moved it into a protected static method inside the logger class. This method is now used by the console and file logger and could be easily used by loggers that will follow.
