### PR TITLE
Fix build error caused by nonconst reference in comparison lambda

### DIFF
--- a/Sources/Display/2D/path_renderer.cpp
+++ b/Sources/Display/2D/path_renderer.cpp
@@ -109,7 +109,7 @@ namespace clan
 		for (size_t y = 0; y < scanlines.size(); y++)
 		{
 			auto &scanline = scanlines[y];
-			std::sort(scanline.edges.begin(), scanline.edges.end(), [](PathScanlineEdge &a, PathScanlineEdge &b) { return a.x < b.x; });
+			std::sort(scanline.edges.begin(), scanline.edges.end(), [](const PathScanlineEdge &a, const PathScanlineEdge &b) { return a.x < b.x; });
 
 			unsigned char *line = mask.get_line_uint8(y / 2);
 


### PR DESCRIPTION
On Linux, I get the following build error on master.

```
2D/path_renderer.cpp:112:103: note:   no known conversion for argument 1 from 'const clan::PathScanlineEdge' to 'clan::PathScanlineEdge&'
```

This small change fixes that.
