### PR TITLE
Added angles and initializer_list to BoxStyle's gradients.

### DIFF
--- a/Sources/API/UI/Style/box_style.h
+++ b/Sources/API/UI/Style/box_style.h
@@ -29,9 +29,10 @@
 #pragma once
 
 #include "../../Display/2D/color.h"
+#include <functional>
+#include <initializer_list>
 #include <memory>
 #include <string>
-#include <functional>
 
 namespace clan
 {
@@ -46,10 +47,17 @@ namespace clan
 		BoxStyle();
 		~BoxStyle();
 
-		/// \brief Copy assignment operator (does not copy the style, use clone() if you want that)
-		BoxStyle &operator =(const BoxStyle &copy);
+		/*! Copy assignment operator overload.
+		 *  \note Only the reference to the style is copied. Changes made to
+		 *        one object will also be seen on the other object.
+		 *        Use clone() if you want a new style object.
+		 */
+		BoxStyle &operator=(const BoxStyle &copy);
 
-		// \brief Copy the entire style (not just the implementation)
+		/*! Creates a new copy of the box style object.
+		 *  \note Creates a new box style object with the same attributes.
+		 *        Changes made to one object will not affect the other object.
+		 */
 		BoxStyle clone() const;
 
 		void set_layout_none();
@@ -77,10 +85,32 @@ namespace clan
 
 		void set_background_none();
 		void set_background(const Colorf &color);
+
+		/*! Sets a gradient background for the box.
+		 *
+		 *  \param gradient_stops An initializer list containing one or more
+		 *                        color-point pair denoting gradient stops.
+		 *  \param angle          Gradient direction. Defaults to `0.0f`, which
+		 *                        makes the gradient go from left to right.
+		 *
+		 *  Example usage:
+		 *  ```cpp
+		 *  // This makes the box background a rainbow of 6 colors going from
+		 *  // the top to bottom.
+		 *  set_background_gradient({{ clan::Colorf::white, 0.0f }, { clan::Colorf::black, 1.0f }}, 180.0f);
+		 *
+		 *  // This makes the box background a semi-transparent 6-color rainbow
+		 *  // running diagonally.
+		 *  set_background_gradient({
+		 *          { {255,0,0,40}, 0.0f }, { {255,255,0,80}, 0.2f }, { {0,255,0,160}, 0.4f },
+		 *          { {0,255,255,160}, 0.6f }, { {0,0,255,80}, 0.8f }, { {255,0,255,40}, 1.0f }
+		 *          }, 45.0f);
+		 *  ```
+		 */
+		void set_background_gradient(std::initializer_list<std::pair<Colorf,float>> gradient_stops, float angle_degrees = 0.0f);
+
 		void set_background_gradient_to_bottom(const Colorf &top, const Colorf &bottom);
-		void set_background_gradient_to_bottom(const Colorf &stop1, float t1, const Colorf &stop2, float t2, const Colorf &stop3, float t3, const Colorf &stop4, float t4);
 		void set_background_gradient_to_right(const Colorf &left, const Colorf &right);
-		void set_background_gradient_to_right(const Colorf &stop1, float t1, const Colorf &stop2, float t2, const Colorf &stop3, float t3, const Colorf &stop4, float t4);
 		void set_background_image(const std::string &url);
 		void set_background_size_contain();
 

--- a/Sources/API/UI/Style/box_style.h
+++ b/Sources/API/UI/Style/box_style.h
@@ -95,8 +95,8 @@ namespace clan
 		 *
 		 *  Example usage:
 		 *  ```cpp
-		 *  // This makes the box background a rainbow of 6 colors going from
-		 *  // the top to bottom.
+		 *  // This makes the box background a white-to-black gradient going
+		 *  // from the top to bottom.
 		 *  set_background_gradient({{ clan::Colorf::white, 0.0f }, { clan::Colorf::black, 1.0f }}, 180.0f);
 		 *
 		 *  // This makes the box background a semi-transparent 6-color rainbow

--- a/Sources/UI/Style/box_style.cpp
+++ b/Sources/UI/Style/box_style.cpp
@@ -148,44 +148,27 @@ namespace clan
 		if (impl->style_changed) impl->style_changed();
 	}
 
-	void BoxStyle::set_background_gradient_to_bottom(const Colorf &top, const Colorf &bottom)
+	void BoxStyle::set_background_gradient(std::initializer_list<std::pair<Colorf,float>> gradient_stops, float angle_degrees)
 	{
 		impl->background.stops.clear();
-		impl->background.stops.push_back(BoxGradientStop(top, 0.0f));
-		impl->background.stops.push_back(BoxGradientStop(bottom, 1.0f));
-		impl->background.angle = 180.0f;
+		const std::pair<Colorf, float> * it = gradient_stops.begin();
+		while (it != gradient_stops.end())
+		{
+			impl->background.stops.emplace_back(it->first, it->second);
+			it++;
+		}
+		impl->background.angle = angle_degrees;
 		if (impl->style_changed) impl->style_changed();
 	}
 
-	void BoxStyle::set_background_gradient_to_bottom(const Colorf &stop1, float t1, const Colorf &stop2, float t2, const Colorf &stop3, float t3, const Colorf &stop4, float t4)
+	void BoxStyle::set_background_gradient_to_bottom(const Colorf &top, const Colorf &bottom)
 	{
-		impl->background.stops.clear();
-		impl->background.stops.push_back(BoxGradientStop(stop1, t1));
-		impl->background.stops.push_back(BoxGradientStop(stop2, t2));
-		impl->background.stops.push_back(BoxGradientStop(stop3, t3));
-		impl->background.stops.push_back(BoxGradientStop(stop4, t4));
-		impl->background.angle = 180.0f;
-		if (impl->style_changed) impl->style_changed();
+		set_background_gradient({{ top, 0.0f }, { bottom, 1.0f }}, 180.0f);
 	}
 
 	void BoxStyle::set_background_gradient_to_right(const Colorf &left, const Colorf &right)
 	{
-		impl->background.stops.clear();
-		impl->background.stops.push_back(BoxGradientStop(left, 0.0f));
-		impl->background.stops.push_back(BoxGradientStop(right, 1.0f));
-		impl->background.angle = 0.0f;
-		if (impl->style_changed) impl->style_changed();
-	}
-
-	void BoxStyle::set_background_gradient_to_right(const Colorf &stop1, float t1, const Colorf &stop2, float t2, const Colorf &stop3, float t3, const Colorf &stop4, float t4)
-	{
-		impl->background.stops.clear();
-		impl->background.stops.push_back(BoxGradientStop(stop1, t1));
-		impl->background.stops.push_back(BoxGradientStop(stop2, t2));
-		impl->background.stops.push_back(BoxGradientStop(stop3, t3));
-		impl->background.stops.push_back(BoxGradientStop(stop4, t4));
-		impl->background.angle = 0.0f;
-		if (impl->style_changed) impl->style_changed();
+		set_background_gradient({{ left, 0.0f }, { right, 1.0f }}, 0.0f);
 	}
 
 	void BoxStyle::set_background_image(const std::string &url)

--- a/Sources/UI/Style/box_style_impl.cpp
+++ b/Sources/UI/Style/box_style_impl.cpp
@@ -365,20 +365,20 @@ namespace clan
 
 			if (!background.stops.empty())
 			{
-				// To do: use background.angle to calculate start and end point
+				Pointf center = padding_box.get_center();
+				Pointf delta;
+				{
+					float radians = background.angle * M_PI / 180.0f;
+					float M = std::cos(radians) * (0.5f * padding_box.get_height()) + (0.5f * padding_box.get_width()) * std::tan(radians);
+					delta.x = M * std::sin(radians);
+					delta.y = M * std::cos(radians);
+				}
 
 				Brush brush;
 				brush.type = BrushType::linear;
-				if (background.angle == 0.0f)
-				{
-					brush.start_point = Pointf(padding_box.left, padding_box.top);
-					brush.end_point = Pointf(padding_box.right, padding_box.top);
-				}
-				else
-				{
-					brush.start_point = Pointf(padding_box.left, padding_box.top);
-					brush.end_point = Pointf(padding_box.left, padding_box.bottom);
-				}
+				brush.start_point = center - delta;
+				brush.end_point   = center + delta;
+
 				for (const BoxGradientStop &stop : background.stops)
 					brush.stops.push_back(BrushGradientStop(stop.color, stop.position));
 


### PR DESCRIPTION
Angled linear gradient backgrounds is implemented based on the CSS linear-gradient function, described here:

https://developer.mozilla.org/en-US/docs/Web/CSS/linear-gradient

A new set_background_gradient() function that accepts an initializer list has been added to allow for more gradient stops to be added into the BoxStyle, replacing some of the less flexible functions within that class. 

Sample:
![2015-01-15-001012_1366x768_scrot](https://cloud.githubusercontent.com/assets/706074/5743175/9a1f9284-9c52-11e4-9f9b-ba928352817a.png)