### PR TITLE
Fixed linear gradient implementation.

### DIFF
--- a/Sources/API/UI/Style/box_style.h
+++ b/Sources/API/UI/Style/box_style.h
@@ -86,12 +86,19 @@ namespace clan
 		void set_background_none();
 		void set_background(const Colorf &color);
 
-		/*! Sets a gradient background for the box.
+		/*! Sets a linear gradient background (based on CSS spec) for the box.
 		 *
 		 *  \param gradient_stops An initializer list containing one or more
-		 *                        color-point pair denoting gradient stops.
-		 *  \param angle          Gradient direction. Defaults to `0.0f`, which
-		 *                        makes the gradient go from left to right.
+		 *                        `(Colorf, float)` pairs that denote the color
+		 *                        and location of a color stop on the gradient.
+		 *                        Stop location values are normalized between
+		 *                        `0.0f` (0% in CSS) and `1.0f` (100%).
+		 *  \param angle          Gradient vector angle at clock-wise rotation.
+		 *                        Defaults to `0`, where the gradient points
+		 *                        upwards (i.e. going from bottom to top).
+		 *                        Setting this to `45` degrees will make the
+		 *                        gradient run diagonally from bottom-left to
+		 *                        the top-right.
 		 *
 		 *  Example usage:
 		 *  ```cpp
@@ -107,7 +114,7 @@ namespace clan
 		 *          }, 45.0f);
 		 *  ```
 		 */
-		void set_background_gradient(std::initializer_list<std::pair<Colorf,float>> gradient_stops, float angle_degrees = 0.0f);
+		void set_background_gradient(std::initializer_list<std::pair<Colorf,float>> gradient_stops, Angle angle = Angle::from_degrees(0.0f));
 
 		void set_background_gradient_to_bottom(const Colorf &top, const Colorf &bottom);
 		void set_background_gradient_to_right(const Colorf &left, const Colorf &right);

--- a/Sources/UI/Style/box_background.h
+++ b/Sources/UI/Style/box_background.h
@@ -53,7 +53,7 @@ namespace clan
 
 		// Linear gradient
 		std::vector<BoxGradientStop> stops;
-		float angle = 0.0f;
+		Angle angle = Angle::from_degrees(0.0f);
 
 		// Image
 		PixelBuffer image;

--- a/Sources/UI/Style/box_style.cpp
+++ b/Sources/UI/Style/box_style.cpp
@@ -148,7 +148,7 @@ namespace clan
 		if (impl->style_changed) impl->style_changed();
 	}
 
-	void BoxStyle::set_background_gradient(std::initializer_list<std::pair<Colorf,float>> gradient_stops, float angle_degrees)
+	void BoxStyle::set_background_gradient(std::initializer_list<std::pair<Colorf,float>> gradient_stops, Angle angle)
 	{
 		impl->background.stops.clear();
 		const std::pair<Colorf, float> * it = gradient_stops.begin();
@@ -157,18 +157,18 @@ namespace clan
 			impl->background.stops.emplace_back(it->first, it->second);
 			it++;
 		}
-		impl->background.angle = angle_degrees;
+		impl->background.angle = angle;
 		if (impl->style_changed) impl->style_changed();
 	}
 
 	void BoxStyle::set_background_gradient_to_bottom(const Colorf &top, const Colorf &bottom)
 	{
-		set_background_gradient({{ top, 0.0f }, { bottom, 1.0f }}, 180.0f);
+		set_background_gradient({{ top, 0.0f }, { bottom, 1.0f }}, Angle::from_degrees(180.0f));
 	}
 
 	void BoxStyle::set_background_gradient_to_right(const Colorf &left, const Colorf &right)
 	{
-		set_background_gradient({{ left, 0.0f }, { right, 1.0f }}, 0.0f);
+		set_background_gradient({{ left, 0.0f }, { right, 1.0f }}, Angle::from_degrees(90.0f));
 	}
 
 	void BoxStyle::set_background_image(const std::string &url)

--- a/Sources/UI/Style/box_style_impl.cpp
+++ b/Sources/UI/Style/box_style_impl.cpp
@@ -365,19 +365,17 @@ namespace clan
 
 			if (!background.stops.empty())
 			{
+				float angle = Angle::from_degrees(background.angle.to_degrees() - 90.0f).normalize().to_radians();
 				Pointf center = padding_box.get_center();
-				Pointf delta;
-				{
-					float radians = background.angle * PI / 180.0f;
-					float M = std::cos(radians) * (0.5f * padding_box.get_height()) + (0.5f * padding_box.get_width()) * std::tan(radians);
-					delta.x = M * std::sin(radians);
-					delta.y = M * std::cos(radians);
-				}
+				Pointf length {
+					0.5f * padding_box.get_width () * std::cos(angle),
+					0.5f * padding_box.get_height() * std::sin(angle)
+				};
 
 				Brush brush;
 				brush.type = BrushType::linear;
-				brush.start_point = center - delta;
-				brush.end_point   = center + delta;
+				brush.start_point = center - length;
+				brush.end_point   = center + length;
 
 				for (const BoxGradientStop &stop : background.stops)
 					brush.stops.push_back(BrushGradientStop(stop.color, stop.position));


### PR DESCRIPTION
The previous implementation doesn't work on all angles. The new implementation now uses `clan::Angle` and follows the CSS specification; positive angles rotate the direction of the gradient clockwise with 0° pointing upwards (gradient runs from the bottom edge to the top edge of the box). 45° makes he gradient run diagonally from the bottom-left to the top-right, 90° makes the gradient run from left to right, and so on...