### PR TITLE
Added display pixel ratio feature and some documentation fixes

### DIFF
--- a/Sources/API/Display/2D/canvas.h
+++ b/Sources/API/Display/2D/canvas.h
@@ -115,16 +115,16 @@ public:
 	/// \brief Returns the current effective projection matrix.
 	const Mat4f &get_projection() const;
 
-	operator GraphicContext&() const {return get_gc();}
+	operator GraphicContext&() const { return get_gc(); }
 
 	/// \brief Returns the current width of the context.
-	inline float get_width() const {return get_gc().get_px_width();}
+	inline float get_width() const { return get_gc().get_dip_width(); }
 
 	/// \brief Returns the current height of the context.
-	inline float get_height() const {return get_gc().get_px_height();}
+	inline float get_height() const { return get_gc().get_dip_height(); }
 
 	/// \brief Returns the current size of the context.
-	inline Sizef get_size() const {return get_gc().get_px_size();}
+	inline Sizef get_size() const { return get_gc().get_dip_size(); }
 
 	/// \brief Returns the current clipping rectangle
 	Rectf get_cliprect() const;

--- a/Sources/API/Display/Image/pixel_buffer.h
+++ b/Sources/API/Display/Image/pixel_buffer.h
@@ -124,26 +124,33 @@ public:
 	/// \brief Create a copy of the pixelbuffer that doesn't share data with the original pixel buffer.
 	PixelBuffer copy(const Rect &rect) const;
 
-	/// \brief Returns the buffer width.
+	/// Retrieves the actual width of the buffer.
 	int get_width() const;
 
-	/// \brief Returns the buffer height.
+	/// Retrieves the actual height of the buffer.
 	int get_height() const;
 
-	/// \brief Returns the width and height of the buffer.
-	Size get_size() const;
+	/// Retrieves the actual size of the buffer.
+	Size get_size() const { return Size{ get_width(), get_height() }; }
 
-	/// \brief Returns the pitch (bytes per scanline).
+	/// Returns the pitch (in bytes per scanline).
 	int get_pitch() const;
 
-	/// \brief Returns with image width in device independent (96 DPI) pixels
-	float get_px_width() const { return get_width() * 96.0f / get_dpi(); }
+	/** Retrieves the pixel ratio of this texture.
+	 *  \return The display pixel ratio set for this texture.
+	 *          A NaN value implies that the texture should use the pixel ratio
+	 *          set in the DisplayWindowProvider.
+	 */
+	float get_pixel_ratio() const;
 
-	/// \brief Returns with image height in device independent (96 DPI) pixels
-	float get_px_height() const { return get_height() * 96.0f / get_dpi(); }
+	/// Returns the device independent width of this texture.
+	float get_dip_width() const { return get_width() / get_pixel_ratio(); }
 
-	/// \brief Returns with image size in device independent (96 DPI) pixels
-	Sizef get_px_size() const { return Sizef(get_px_width(), get_px_height()); }
+	/// Returns the device independent height of this texture.
+	float get_dip_height() const { return get_height() / get_pixel_ratio(); }
+
+	/// Returns the device independent size of this texture.
+	Sizef get_dip_size() const { return Sizef{ get_dip_width(), get_dip_height() }; }
 
 	/// \brief Returns a pointer to the beginning of the pixel buffer.
 	void *get_data();
@@ -234,9 +241,6 @@ public:
 	/// \brief Return color of pixel at the specified coordinates.
 	Colorf get_pixel(int x, int y);
 
-	/// \brief Gets the dots per inch (physical size) for a pixel
-	float get_dpi() const;
-
 /// \}
 /// \name Operations
 /// \{
@@ -306,9 +310,8 @@ public:
 	/// To convert from linear to sRGB use 1.0/2.2
 	void premultiply_gamma(float gamma);
 
-	/// \brief Sets the physical size for a pixel
-	/// \param dpi Pixels/dots per inch in both directions
-	void set_dpi(float dpi);
+	/// Sets the display pixel ratio for this texture.
+	void set_pixel_ratio(float ratio);
 
 /// \}
 /// \name Implementation

--- a/Sources/API/Display/Render/graphic_context.h
+++ b/Sources/API/Display/Render/graphic_context.h
@@ -65,7 +65,7 @@ class RasterizerState;
 class BlendState;
 class DepthStencilState;
 
-/// \brief Polygon culling modes.
+/// Polygon culling modes.
 enum CullMode
 {
 	cull_front,
@@ -73,7 +73,7 @@ enum CullMode
 	cull_front_and_back
 };
 
-/// \brief Polygon filling modes.
+/// Polygon filling modes.
 enum FillMode
 {
 	fill_point,
@@ -81,14 +81,14 @@ enum FillMode
 	fill_polygon
 };
 
-/// \brief Front face modes.
+/// Front face modes.
 enum FaceSide
 {
 	face_clockwise,
 	face_counter_clockwise
 };
 
-/// \brief Compare functions.
+/// Compare functions.
 enum CompareFunction
 {
 	compare_lequal,
@@ -101,7 +101,7 @@ enum CompareFunction
 	compare_never
 };
 
-/// \brief Stencil operations
+/// Stencil operations
 enum StencilOp
 {
 	stencil_keep,
@@ -114,7 +114,7 @@ enum StencilOp
 	stencil_decr_wrap
 };
 
-/// \brief Drawing buffers.
+/// Drawing buffers.
 enum DrawBuffer
 {
 	buffer_none,
@@ -129,11 +129,11 @@ enum DrawBuffer
 	buffer_front_and_back
 };
 
-/// \brief Logic Op
+/// Logic Op
 enum LogicOp
 {
 	logic_clear,
-	logic_and, 
+	logic_and,
 	logic_and_reverse,
 	logic_copy,
 	logic_and_inverted,
@@ -150,56 +150,56 @@ enum LogicOp
 	logic_set
 };
 
-/// \brief Blending functions.
+/// Blending functions.
 enum BlendFunc
 {
-	/// \brief source or destination (0, 0, 0, 0)
+	/// source or destination (0, 0, 0, 0)
 	blend_zero,
 
-	/// \brief source or destination (1, 1, 1, 1)
+	/// source or destination (1, 1, 1, 1)
 	blend_one,
 
-	/// \brief source (Rd, Gd, Bd, Ad)
+	/// source (Rd, Gd, Bd, Ad)
 	blend_dest_color,
 
-	/// \brief destination (Rs, Gs, Bs, As)
+	/// destination (Rs, Gs, Bs, As)
 	blend_src_color,
 
-	/// \brief source (1, 1, 1, 1) - (Rd, Gd, Bd, Ad)
+	/// source (1, 1, 1, 1) - (Rd, Gd, Bd, Ad)
 	blend_one_minus_dest_color,
 
-	/// \brief destination (1, 1, 1, 1) - (Rs, Gs, Bs, As)
+	/// destination (1, 1, 1, 1) - (Rs, Gs, Bs, As)
 	blend_one_minus_src_color,
 
-	/// \brief source or destination (As, As, As, As)
+	/// source or destination (As, As, As, As)
 	blend_src_alpha,
 
-	/// \brief source or destination (1, 1, 1, 1) - (As, As, As, As)
+	/// source or destination (1, 1, 1, 1) - (As, As, As, As)
 	blend_one_minus_src_alpha,
 
-	/// \brief source or destination (Ad, Ad, Ad, Ad)
+	/// source or destination (Ad, Ad, Ad, Ad)
 	blend_dest_alpha,
 
-	/// \brief source or destination (1, 1, 1, 1) - (Ad, Ad, Ad, Ad)
+	/// source or destination (1, 1, 1, 1) - (Ad, Ad, Ad, Ad)
 	blend_one_minus_dest_alpha,
 
-	/// \brief source (f, f, f, 1) - f = min(As, 1 - Ad)
+	/// source (f, f, f, 1) - f = min(As, 1 - Ad)
 	blend_src_alpha_saturate,
 
-	/// \brief source or destination (Rc, Gc, Bc, Ac)
+	/// source or destination (Rc, Gc, Bc, Ac)
 	blend_constant_color,
 
-	/// \brief source or destination (1, 1, 1, 1) - (Rc, Gc, Bc, Ac)
+	/// source or destination (1, 1, 1, 1) - (Rc, Gc, Bc, Ac)
 	blend_one_minus_constant_color,
 
-	/// \brief source or destination (Ac, Ac, Ac, Ac)
+	/// source or destination (Ac, Ac, Ac, Ac)
 	blend_constant_alpha,
 
-	/// \brief source or destination (1, 1, 1, 1) - (Ac, Ac, Ac, Ac)
+	/// source or destination (1, 1, 1, 1) - (Ac, Ac, Ac, Ac)
 	blend_one_minus_constant_alpha
 };
 
-/// \brief Blending equations.
+/// Blending equations.
 enum BlendEquation
 {
 	equation_add,
@@ -209,14 +209,14 @@ enum BlendEquation
 	equation_max
 };
 
-/// \brief Point Sprite Origin
+/// Point Sprite Origin
 enum PointSpriteOrigin
 {
 	origin_upper_left,
 	origin_lower_left
 };
 
-/// \brief Primitive types.
+/// Primitive types.
 enum PrimitivesType
 {
 	type_points,
@@ -228,14 +228,14 @@ enum PrimitivesType
 	type_triangles
 };
 
-/// \brief Y axis direction for viewports, clipping rects, textures and render targets
+/// Y axis direction for viewports, clipping rects, textures and render targets
 enum TextureImageYAxis
 {
-	y_axis_bottom_up,  // OpenGL, origin is lower left with Y going upwards
-	y_axis_top_down    // Direct3D, origin is upper left with Y going downwards
+	y_axis_bottom_up,  //!< OpenGL, origin is lower left with Y going upwards
+	y_axis_top_down    //!< Direct3D, origin is upper left with Y going downwards
 };
 
-/// \brief Standard Program
+/// Standard Program
 enum StandardProgram
 {
 	program_color_only,
@@ -244,7 +244,7 @@ enum StandardProgram
 	program_path
 };
 
-/// \brief Shader language used
+/// Shader language used
 enum ShaderLanguage
 {
 	shader_glsl,
@@ -253,19 +253,19 @@ enum ShaderLanguage
 	num_shader_languages
 };
 
-/// \brief Interface to drawing graphics.
+/// Interface to drawing graphics.
 class GraphicContext
 {
 /// \name Construction
 /// \{
 
 public:
-	/// \brief Constructs a null instance.
+	/// Constructs a null instance.
 	GraphicContext();
 
-	/// \brief Constructs a GraphicContext
-	///
-	/// \param provider = Graphic Context Provider
+	/** Constructs a new graphic context from a provider.
+	 *  \param provider = Graphic Context Provider
+	 */
 	GraphicContext(GraphicContextProvider *provider);
 
 	~GraphicContext();
@@ -274,90 +274,102 @@ public:
 /// \name Attributes
 /// \{
 public:
-	/// \brief Returns true if this object is invalid.
+	/// Returns true if this object is invalid.
 	bool is_null() const { return !impl; }
 
-	/// \brief Throw an exception if this object is invalid.
+	/// Throw an exception if this object is invalid.
 	void throw_if_null() const;
 
-	/// \brief Returns in what range clip space z values are clipped.
+	/// Returns in what range clip space z values are clipped.
 	ClipZRange get_clip_z_range() const;
 
-	/// \brief Returns the Y axis direction for viewports, clipping rects, textures and render targets
+	/// Returns the Y axis direction for viewports, clipping rects, textures and render targets
 	TextureImageYAxis get_texture_image_y_axis() const;
 
-	/// \brief Returns the shader language used
+	/// Returns the shader language used
 	ShaderLanguage get_shader_language() const;
 
-	/// \brief Returns the major version / feature level supported by the hardware
-	///
-	/// For the OpenGL target, this returns the major OpenGL version the driver supports.
-	/// For the Direct3D target, this returns the major feature level.
+	/** Returns the major version / feature level supported by the hardware.
+	 *  For an OpenGL target, this returns the major OpenGL version the driver supports.
+	 *  For a Direct3D target, this returns the major feature level.
+	 */
 	int get_major_version() const;
 
-	/// \brief Returns the major version / feature level supported by the hardware
-	///
-	/// For the OpenGL target, this returns the minor OpenGL version the driver supports.
-	/// For the Direct3D target, this returns the minor feature level.
+	/** Returns the minor version / feature level supported by the hardware.
+	 *  For an OpenGL target, this returns the minor OpenGL version the driver supports.
+	 *  For a Direct3D target, this returns the minor feature level.
+	 */
 	int get_minor_version() const;
 
-	/// \brief Returns true if the hardware supports compute shaders
-	///
-	/// This always returns true for OpenGL 4.3 or newer, or Direct3D 11.0 or newer. 
-	/// For Direct3D 10.0 and 10.1 the support for compute shaders is optional.
+	/** Returns `true` if the hardware supports compute shaders.
+	 *  This function will always returns true for OpenGL 4.3 or newer, or
+	 *  Direct3D 11.0 or newer. For Direct3D 10.0 and 10.1, the support for
+	 *  compute shaders is optional.
+	 */
 	bool has_compute_shader_support() const;
 
-	/// \brief Returns the currently selected texture for the specified index.
-	///
-	/// \param index = 0 to x, the index of the texture
-	/// \return The texture. Use texture.is_null() to determine if the texture was not selected
+	/** Retrieves the texture selected in this context with an index number.
+	 *  \param index The texture index number to retrieve. [0 to n]
+	 *  \return The texture on the specified index. Use Texture::is_null() to
+	 *          determine whether the texture has been selected by the context.
+	 */
 	Texture get_texture(int index) const;
 
-	/// \brief Returns the currently selected textures
-	///
-	/// \return The selected textures (placed at unit_index 0 to size()-1).  These may contain null textures if textures were not selected
+	/** Returns the textures currently selected in this context.
+	 *  \return A vector containing the selected textures. The vector may
+	 *          contain null (unselected) texture elements within it..
+	 */
 	std::vector<Texture> get_textures() const;
 
-	/// \brief Returns the currently selected write frame buffer.
-	///
-	/// \return The frame buffer. Use frame_buffer.is_null() to determine if the frame buffer was not selected
+	/** Returns the currently selected write frame buffer.
+	 *  \return The frame buffer. Use frame_buffer.is_null() to determine if the frame buffer was not selected
+	 */
 	FrameBuffer get_write_frame_buffer() const;
 
-	/// \brief Returns the currently selected read frame buffer.
+	/// Returns the currently selected read frame buffer.
 	///
 	/// \return The frame buffer. Use frame_buffer.is_null() to determine if the frame buffer was not selected
 	FrameBuffer get_read_frame_buffer() const;
 
-	/// \brief Returns the currently selected program object
+	/// Returns the currently selected program object
 	ProgramObject get_program_object() const;
 
-	/// \brief Returns the current width of the context.
+	/// Returns the current actual width of the context.
 	int get_width() const;
 
-	/// \brief Returns the current height of the context.
+	/// Returns the current actual height of the context.
 	int get_height() const;
 
-	/// \brief Returns the current size of the context.
+	/// Returns the current actual size of the context.
 	Size get_size() const;
 
-	/// \brief Returns with image width in device independent (96 DPI) pixels
-	float get_px_width() const { return get_width() * 96.0f / get_dpi(); }
+	/// Retrieves the number of physical pixels or dots per inch of the screen.
+	/// \seealso Resolution Independence
+	float get_ppi() const;
 
-	/// \brief Returns with image height in device independent (96 DPI) pixels
-	float get_px_height() const { return get_height() * 96.0f / get_dpi(); }
+	/// Retrieves the display pixel ratio of the context.
+	/// \seealso Resolution Independence
+	float get_pixel_ratio() const;
 
-	/// \brief Returns with image size in device independent (96 DPI) pixels
-	Sizef get_px_size() const { return Sizef(get_px_width(), get_px_height()); }
+	/// Calculates the device independent width of the context.
+	/// \seealso Resolution Independence
+	float get_dip_width() const { return get_width() / get_pixel_ratio(); }
 
-	/// \brief Physical pixels/dots per inch
-	float get_dpi() const;
+	/// Calculates the device independent height of the context.
+	/// \seealso Resolution Independence
+	float get_dip_height() const { return get_height() / get_pixel_ratio(); }
 
-	/// \brief Returns the maximum size of a texture this graphic context supports.
-	/** <p>It returns Size(0,0) if there is no known limitation to the max
-	    texture size.</p>*/
+	/// Calculates the device independent dimensions of the context.
+	/// \seealso Resolution Independence
+	Sizef get_dip_size() const { return Sizef{ get_dip_width(), get_dip_height() }; }
+
+	/** Retrieves the maximum size for a texture that this graphic context will
+	 *  allow. Size(0, 0) will be returned if there is no known limitation to
+	 *  the maximum texture size allowed for the context.
+	 */
 	Size get_max_texture_size() const;
 
-	/// \brief Returns the provider for this graphic context.
+	/// Returns the provider for this graphic context.
 	GraphicContextProvider *get_provider();
 
 	const GraphicContextProvider * get_provider() const;
@@ -366,140 +378,143 @@ public:
 /// \name Operations
 /// \{
 public:
-	/// \brief Create a new default graphic context compatible with this one
+	/// Create a new default graphic context compatible with this one
 	GraphicContext create() const;
 
-	/// \brief Create a new default graphic context with a frame buffer selected
+	/// Create a new default graphic context with a frame buffer selected
 	GraphicContext create(FrameBuffer &buffer) const;
 
-	/// \brief Create a new default graphic context cloned with this one
+	/// Create a new default graphic context cloned with this one
 	GraphicContext clone() const;
 
-	/// \brief Return the content of the read buffer into a pixel buffer.
+	/// Return the content of the read buffer into a pixel buffer.
 	PixelBuffer get_pixeldata(const Rect& rect, TextureFormat texture_format = tf_rgba8, bool clamp = true);
 
-	/// \brief Return the content of the read buffer into a pixel buffer.
+	/// Return the content of the read buffer into a pixel buffer.
 	PixelBuffer get_pixeldata(TextureFormat texture_format = tf_rgba8, bool clamp = true);
 
-	/// \brief Returns true if this frame buffer object is owned by this graphic context.
-	///
-	/// Frame buffer objects cannot be shared between graphic contexts.  This function verifies that the frame buffer object
-	/// belongs to this graphic context.
+	/** Returns `true` if this frame buffer object is owned by this graphic
+	 *  context.
+	 *
+	 *  Frame buffer objects cannot be shared between graphic contexts. This
+	 *  function will verify if the frame buffer object belongs to this graphic
+	 *  context.
+	 */
 	bool is_frame_buffer_owner(const FrameBuffer &fb);
 
-	/// \brief Sets the current frame buffer.
+	/// Sets the current frame buffer.
 	void set_frame_buffer(const FrameBuffer &write_buffer);
 	void set_frame_buffer(const FrameBuffer &write_buffer, const FrameBuffer &read_buffer);
 
-	/// \brief Resets the current frame buffer to be the initial frame buffer.
+	/// Resets the current frame buffer to be the initial frame buffer.
 	void reset_frame_buffer();
 
-	/// \brief Select uniform buffer into index
+	/// Select uniform buffer into index
 	void set_uniform_buffer(int index, const UniformBuffer &buffer);
 
-	/// \brief Remove uniform buffer from index
+	/// Remove uniform buffer from index
 	void reset_uniform_buffer(int index);
 
-	/// \brief Select storage buffer into index
+	/// Select storage buffer into index
 	void set_storage_buffer(int index, const StorageBuffer &buffer);
 
-	/// \brief Remove storage buffer from index
+	/// Remove storage buffer from index
 	void reset_storage_buffer(int index);
 
-	/// \brief Select texture into index.
+	/// Select texture into index.
 	///
 	/// \param unit_index = 0 to x, the index of this texture
 	/// \param texture = The texture to select.  This can be an empty texture Texture()
 	void set_texture(int unit_index, const Texture &texture);
 
-	/// \brief Select textures
+	/// Select textures
 	///
 	/// Only textures units from 0 to textures.size()-1 are set.
 	///
 	/// \param textures = The texture to select (placed at unit_index 0 to texture.size()-1).  These may contain null textures
 	void set_textures(std::vector<Texture> &textures);
 
-	/// \brief Remove texture from index.
+	/// Remove texture from index.
 	///
 	/// \param unit_index = 0 to x, the index of the texture
 	void reset_texture(int unit_index);
 
-	/// \brief Remove all selected textures
+	/// Remove all selected textures
 	void reset_textures();
 
-	/// \brief Select texture image into index.
+	/// Select texture image into index.
 	///
 	/// \param unit_index = 0 to x, the index of this texture
 	/// \param texture = The texture to select.  This can be an empty texture Texture()
 	void set_image_texture(int unit_index, const Texture &texture);
 
-	/// \brief Select texture images
+	/// Select texture images
 	///
 	/// Only textures units from 0 to textures.size()-1 are set.
 	///
 	/// \param textures = The texture to select (placed at unit_index 0 to texture.size()-1).  These may contain null textures
 	void set_image_texture(std::vector<Texture> &textures);
 
-	/// \brief Remove texture from index.
+	/// Remove texture from index.
 	///
 	/// \param unit_index = 0 to x, the index of the texture
 	void reset_image_texture(int unit_index);
 
-	/// \brief Remove all selected textures
+	/// Remove all selected textures
 	void reset_image_textures();
 
-	/// \brief Set active rasterizer state
+	/// Set active rasterizer state
 	void set_rasterizer_state(const RasterizerState &state);
 
-	/// \brief Set active blend state
+	/// Set active blend state
 	void set_blend_state(const BlendState &state, const Colorf &blend_color = Colorf::white, unsigned int sample_mask = 0xffffffff);
 
-	/// \brief Set active depth stencil state
+	/// Set active depth stencil state
 	void set_depth_stencil_state(const DepthStencilState &state, int stencil_ref = 0);
 
-	/// \brief Set active rasterizer state
+	/// Set active rasterizer state
 	void reset_rasterizer_state();
 
-	/// \brief Set active blend state
+	/// Set active blend state
 	void reset_blend_state();
 
-	/// \brief Set active depth stencil state
+	/// Set active depth stencil state
 	void reset_depth_stencil_state();
 
-	/// \brief Set active program object to the standard program specified.
+	/// Set active program object to the standard program specified.
 	void set_program_object(StandardProgram standard_program);
 
-	/// \brief Set active program object.
+	/// Set active program object.
 	///
 	/// \param program = Program to set
 	void set_program_object(const ProgramObject &program);
 
-	/// \brief Remove active program object.
+	/// Remove active program object.
 	void reset_program_object();
 
-	/// \brief Returns true if this primitives array is owned by this graphic context.
+	/// Returns true if this primitives array is owned by this graphic context.
 	///
 	/// Primitive array objects cannot be shared between graphic contexts.  This function verifies that the primitives array
 	/// belongs to this graphic context.
 	bool is_primitives_array_owner(const PrimitivesArray &primitives_array);
 
-	/// \brief Draw primitives on gc.
+	/// Draw primitives on gc.
 	void draw_primitives(PrimitivesType type, int num_vertices, const PrimitivesArray &array);
 
-	/// \brief Set the primitives array on the gc.
+	/// Set the primitives array on the gc.
 	void set_primitives_array(const PrimitivesArray &array);
 
-	/// \brief Draws primitives from the current assigned primitives array.
+	/// Draws primitives from the current assigned primitives array.
 	void draw_primitives_array(PrimitivesType type, int num_vertices);
 
-	/// \brief Draw primitives array
+	/// Draw primitives array
 	///
 	/// \param type = Primitives Type
 	/// \param offset = value
 	/// \param num_vertices = value
 	void draw_primitives_array(PrimitivesType type, int offset, int num_vertices);
 
-	/// \brief Draw primitives array instanced
+	/// Draw primitives array instanced
 	///
 	/// \param type = Primitives Type
 	/// \param offset = value
@@ -507,17 +522,17 @@ public:
 	/// \param instance_count = number of instances drawn
 	void draw_primitives_array_instanced(PrimitivesType type, int offset, int num_vertices, int instance_count);
 
-	/// \brief Sets current elements array buffer
+	/// Sets current elements array buffer
 	void set_primitives_elements(ElementArrayBuffer &element_array);
 
-	/// \brief Sets current elements array buffer
+	/// Sets current elements array buffer
 	template<typename Type>
 	void set_primitives_elements(ElementArrayVector<Type> &element_array)
 	{
 		set_primitives_elements((ElementArrayBuffer&)element_array);
 	}
 
-	/// \brief Draw primitives elements
+	/// Draw primitives elements
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -525,7 +540,7 @@ public:
 	/// \param offset = void
 	void draw_primitives_elements(PrimitivesType type, int count, VertexAttributeDataType indices_type, size_t offset = 0);
 
-	/// \brief Draw primitives elements instanced
+	/// Draw primitives elements instanced
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -534,10 +549,10 @@ public:
 	/// \param instance_count = number of instances drawn
 	void draw_primitives_elements_instanced(PrimitivesType type, int count, VertexAttributeDataType indices_type, size_t offset, int instance_count);
 
-	/// \brief Resets current elements array buffer
+	/// Resets current elements array buffer
 	void reset_primitives_elements();
 
-	/// \brief Draw primitives elements
+	/// Draw primitives elements
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -546,7 +561,7 @@ public:
 	/// \param offset = void
 	void draw_primitives_elements(PrimitivesType type, int count, ElementArrayBuffer &element_array, VertexAttributeDataType indices_type, size_t offset = 0);
 
-	/// \brief Draw primitives elements
+	/// Draw primitives elements
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -558,7 +573,7 @@ public:
 		draw_primitives_elements(type, count, (ElementArrayBuffer&)element_array, type_unsigned_int, offset * sizeof(unsigned int));
 	}
 
-	/// \brief Draw primitives elements
+	/// Draw primitives elements
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -570,7 +585,7 @@ public:
 		draw_primitives_elements(type, count, (ElementArrayBuffer&)element_array, type_unsigned_short, offset * sizeof(unsigned short));
 	}
 
-	/// \brief Draw primitives elements
+	/// Draw primitives elements
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -582,7 +597,7 @@ public:
 		draw_primitives_elements(type, count, (ElementArrayBuffer&)element_array, type_unsigned_byte, offset * sizeof(unsigned char));
 	}
 
-	/// \brief Draw primitives elements instanced
+	/// Draw primitives elements instanced
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -592,7 +607,7 @@ public:
 	/// \param instance_count = number of instances drawn
 	void draw_primitives_elements_instanced(PrimitivesType type, int count, ElementArrayBuffer &element_array, VertexAttributeDataType indices_type, size_t offset, int instance_count);
 
-	/// \brief Draw primitives elements instanced
+	/// Draw primitives elements instanced
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -605,7 +620,7 @@ public:
 		draw_primitives_elements_instanced(type, count, (ElementArrayBuffer&)element_array, type_unsigned_int, offset * sizeof(unsigned int), instance_count);
 	}
 
-	/// \brief Draw primitives elements instanced
+	/// Draw primitives elements instanced
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -618,7 +633,7 @@ public:
 		draw_primitives_elements_instanced(type, count, (ElementArrayBuffer&)element_array, type_unsigned_short, offset * sizeof(unsigned short), instance_count);
 	}
 
-	/// \brief Draw primitives elements instanced
+	/// Draw primitives elements instanced
 	///
 	/// \param type = Primitives Type
 	/// \param count = value
@@ -631,52 +646,52 @@ public:
 		draw_primitives_elements_instanced(type, count, (ElementArrayBuffer&)element_array, type_unsigned_byte, offset * sizeof(unsigned char), instance_count);
 	}
 
-	/// \brief Reset the primitives arrays.
+	/// Reset the primitives arrays.
 	void reset_primitives_array();
 
-	/// \brief Execute a compute shader.
+	/// Execute a compute shader.
 	void dispatch(int x = 1, int y = 1, int z = 1);
 
-	/// \brief Clears the whole context using the specified color.
+	/// Clears the whole context using the specified color.
 	void clear(const Colorf &color = Colorf::black);
 
-	/// \brief Clear the stencil buffer
+	/// Clear the stencil buffer
 	///
 	/// \param value value to clear to.
 	void clear_stencil(int value = 0);
 
-	/// \brief Clear the depth buffer
+	/// Clear the depth buffer
 	///
 	/// \param value: value to clear to. Range 0.0 - 1.0.
 	void clear_depth(float value = 0);
 
-	/// \brief Set the current clipping rectangle.
+	/// Set the current clipping rectangle.
 	void set_scissor(const Rect &rect, TextureImageYAxis y_axis);
 
-	/// \brief Removes the set clipping rectangle 
+	/// Removes the set clipping rectangle
 	void reset_scissor();
 
-	/// \brief Set the viewport to be used in user projection map mode.
+	/// Set the viewport to be used in user projection map mode.
 	///
 	/// \param viewport = The viewport to set
 	void set_viewport(const Rectf &viewport);
 
-	/// \brief Set the specified viewport to be used in user projection map mode.
+	/// Set the specified viewport to be used in user projection map mode.
 	///
 	/// \param index = The viewport index (0 to x)
 	/// \param viewport = The viewport to set
 	void set_viewport(int index, const Rectf &viewport);
 
-	/// \brief Specifies the depth range for all viewports
+	/// Specifies the depth range for all viewports
 	void set_depth_range(float n, float f);
 
-	/// \brief Specifies the depth range for the specified viewport
+	/// Specifies the depth range for the specified viewport
 	void set_depth_range(int viewport, float n, float f);
 
-	/// \brief Set used draw buffer.
+	/// Set used draw buffer.
 	void set_draw_buffer(DrawBuffer buffer);
 
-	/// \brief Flush the command buffer
+	/// Flush the command buffer
 	void flush();
 
 /// \}

--- a/Sources/API/Display/Render/render_batcher.h
+++ b/Sources/API/Display/Render/render_batcher.h
@@ -49,17 +49,19 @@ class RenderBatcher
 public:
 	virtual ~RenderBatcher() { }
 
-	/// \brief Flush
-	///
-	/// \param gc = Graphic Context
+	/** Flush render batcher contents.
+	 *  \param gc Graphic context to flush contents to.
+	 */
 	virtual void flush(GraphicContext &gc) = 0;
 
-	/// \brief Matrix changed
-	///
-	/// \param modelview = Mat4f
-	/// \param projection = Mat4f
-	/// \param image_yaxis = The image Y axis, to use where "projection" is not used
-	virtual void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float dpi) = 0;
+	/** Function to call when matrices are changed.
+	 *  \param modelview    New wodel view matrix.
+	 *  \param projection   New projection matrix.
+	 *  \param image_yaxis  The image Y axis to use where `projection` is not
+	 *                      used.
+	 *  \param pixel_ratio  The display pixel ratio to use when rendering.
+	 */
+	virtual void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float pixel_ratio) = 0;
 /// \}
 };
 

--- a/Sources/API/Display/Render/texture_2d.h
+++ b/Sources/API/Display/Render/texture_2d.h
@@ -37,115 +37,113 @@ namespace clan
 /// \addtogroup clanDisplay_Display clanDisplay Display
 /// \{
 
-/// \brief 2D texture object class.
+/// 2D texture object class.
 class Texture2D : public Texture
 {
 /// \name Construction
 /// \{
 public:
-	/// \brief Constructs a null instance.
+	/// Constructs a null instance.
 	Texture2D();
 
-	/// \brief Constructs a texture from an implementation
-	///
-	/// \param impl = The implementation
+	/** Constructs a texture from an implementation.
+	 *  \param impl The Texture object implementation.
+	 */
 	Texture2D(const std::shared_ptr<Texture_Impl> &impl) : Texture(impl) { }
 
-	/// \brief Constructs a Texture
-	///
-	/// \param context = Graphic Context
-	/// \param width = value
-	/// \param height = value
-	/// \param internal_format = Texture Format
-	/// \param levels = Mipmap levels for the texture. 0 = all levels
-	Texture2D(GraphicContext &context, int width, int height, TextureFormat texture_format = tf_rgba8, int levels = 1);
+	/** Constructs a new Texture object.
+	 *  \param context  Graphic context to construct the texture on.
+	 *  \param width    Width of the new texture.
+	 *  \param height   Height of the new texture.
+	 *  \param format   Data format of the new texture.
+	 *  \param levels   Number of mipmap levels for the new texture. Setting
+	 *                  this to `0` enables all levels.
+	 */
+	Texture2D(GraphicContext &context, int width, int height, TextureFormat format = tf_rgba8, int levels = 1);
 
-	/// \brief Constructs a Texture
-	///
-	/// \param context = Graphic Context
-	/// \param size = Size
-	/// \param internal_format = Texture Format
-	/// \param levels = Mipmap levels for the texture. 0 = all levels
+	/** Constructs a new Texture object.
+	 *  \param context  Graphic context to construct the texture on.
+	 *  \param size     Size of the new texture.
+	 *  \param format   Data format of the new texture.
+	 *  \param levels   Number of mipmap levels for the new texture. Setting
+	 *                  this to `0` enables all levels.
+	 */
 	Texture2D(GraphicContext &context, const Size &size, TextureFormat texture_format = tf_rgba8, int levels = 1);
 
-	Texture2D(
-		GraphicContext &context,
-		const std::string &fullname, const ImageImportDescription &import_desc = ImageImportDescription ());
-
-	Texture2D(
-		GraphicContext &context,
-		const std::string &filename,
-		const FileSystem &fs, const ImageImportDescription &import_desc = ImageImportDescription ());
-
-	Texture2D(
-		GraphicContext &context,
-		IODevice &file, const std::string &image_type, const ImageImportDescription &import_desc = ImageImportDescription ());
+	Texture2D(GraphicContext &context, const std::string &fullname, const ImageImportDescription &import_desc = {});
+	Texture2D(GraphicContext &context, const std::string &filename, const FileSystem &fs, const ImageImportDescription &import_desc = {});
+	Texture2D(GraphicContext &context, IODevice &file, const std::string &image_type, const ImageImportDescription &import_desc = {});
 
 	Texture2D(GraphicContext &context, const PixelBuffer &image, bool is_srgb = false);
 	Texture2D(GraphicContext &context, const PixelBuffer &image, const Rect &src_rect, bool is_srgb = false);
-
 /// \}
 
 /// \name Attributes
 /// \{
 public:
-	/// \brief Get the texture width.
+	/// Retrieves the actual width of the texture in the display.
 	int get_width() const;
 
-	/// \brief Get the texture height.
+	/// Retrieves the actual height of the texture in the display.
 	int get_height() const;
 
-	/// \brief Get the texture size.
-	Size get_size() const;
+	/// Retrieves the actual size of the texture.
+	Size get_size() const { return Size{ get_width(), get_height() }; }
 
-	/// \brief Returns with texture width in device independent (96 DPI) pixels
-	float get_px_width() const { return get_width() * 96.0f / get_dpi(); }
+	/** Retrieves the pixel ratio of this texture.
+	 *  \return The display pixel ratio set for this texture.
+	 *          A NaN value implies that the texture should use the pixel ratio
+	 *          set in the DisplayWindowProvider.
+	 */
+	float get_pixel_ratio() const;
 
-	/// \brief Returns with texture height in device independent (96 DPI) pixels
-	float get_px_height() const { return get_height() * 96.0f / get_dpi(); }
+	/// Returns the device independent width of this texture.
+	float get_dip_width() const { return get_width() / get_pixel_ratio(); }
 
-	/// \brief Returns with texture size in device independent (96 DPI) pixels
-	Sizef get_px_size() const { return Sizef(get_px_width(), get_px_height()); }
+	/// Returns the device independent height of this texture.
+	float get_dip_height() const { return get_height() / get_pixel_ratio(); }
 
-	/// \brief Physical pixels/dots per inch
-	float get_dpi() const;
+	/// Returns the device independent size of this texture.
+	Sizef get_dip_size() const { return Sizef{ get_dip_width(), get_dip_height() }; }
 
-	/// \brief Retrieve image data from texture.
+	/// Retrieve image data from texture.
 	PixelBuffer get_pixeldata(GraphicContext &gc, int level = 0) const;
 
-	/// \brief Get pixeldata
-	///
-	/// \param format = Pixel Format
-	/// \param level = value
-	///
-	/// \return Pixel Buffer
+	/** Retrieve image data from this texture.
+	 *  \param format Output data format.
+	 *  \param level  Mipmap level of the texture to retrieve data from.
+	 */
 	PixelBuffer get_pixeldata(GraphicContext &gc, TextureFormat texture_format, int level = 0) const;
 
-	/// \brief Get the texture wrap mode for the s coordinate.
+	/// Get the texture wrap mode for the s coordinate.
 	TextureWrapMode get_wrap_mode_s() const;
 
-	/// \brief Get the texture wrap mode for the t coordinate.
+	/// Get the texture wrap mode for the t coordinate.
 	TextureWrapMode get_wrap_mode_t() const;
 /// \}
 
 /// \name Operations
 /// \{
 public:
-	/// \brief Upload image to texture.
-	///
-	/// \param context Graphic context to use for the request
-	/// \param image Image to upload.
-	/// \param level Mipmap level-of-detail number.
+	/** Upload image to this texture.
+	 *  \param context Graphic context to use for the request.
+	 *  \param image   Image to upload.
+	 *  \param level   Mipmap level-of-detail number.
+	 */
 	void set_image(
 		GraphicContext &context,
 		const PixelBuffer &image,
 		int level = 0);
 
-	/// \brief Upload image to sub texture.
-	///
-	/// \param context Graphic context to use for the request
-	/// \param image Image to upload.
-	/// \param level Mipmap level-of-detail number.
+	/** Upload image to sub-texture.
+	 *  \param context Graphic context to use for the request.
+	 *  \param x       The horizontal point in the texture to write the new
+	 *                 sub-texture image onto.
+	 *  \param y       The vertical point in the texture to write the new
+	 *                 sub-texture image onto.
+	 *  \param image   Image to upload.
+	 *  \param level   Mipmap level-of-detail number.
+	 */
 	void set_subimage(
 		GraphicContext &context,
 		int x,
@@ -154,6 +152,13 @@ public:
 		const Rect &src_rect,
 		int level = 0);
 
+	/** Upload image to sub-texture.
+	 *  \param context Graphic context to use for the request.
+	 *  \param point   Point in the texture to write the new sub-texture image.
+	 *                 onto.
+	 *  \param image   Image to upload.
+	 *  \param level   Mipmap level-of-detail number.
+	 */
 	void set_subimage(
 		GraphicContext &context,
 		const Point &point,
@@ -161,7 +166,7 @@ public:
 		const Rect &src_rect,
 		int level = 0);
 
-	/// \brief Copy image data from a graphic context.
+	/// Copy image data from a graphic context.
 	void copy_image_from(
 		GraphicContext &context,
 		int level,
@@ -182,7 +187,7 @@ public:
 		int level = 0,
 		TextureFormat texture_format = tf_rgba8);
 
-	/// \brief Copy sub image data from a graphic context.
+	/// Copy sub image data from a graphic context.
 	void copy_subimage_from(
 		GraphicContext &context,
 		int offset_x,
@@ -203,9 +208,8 @@ public:
 		TextureWrapMode wrap_s,
 		TextureWrapMode wrap_t);
 
-	/// \brief Sets the physical size for a pixel
-	/// \param dpi Pixels/dots per inch in both directions
-	void set_dpi(float dpi);
+	/// Sets the display pixel ratio for this texture.
+	void set_pixel_ratio(float ratio);
 
 /// \}
 };

--- a/Sources/API/Display/Render/texture_2d_array.h
+++ b/Sources/API/Display/Render/texture_2d_array.h
@@ -39,92 +39,105 @@ namespace clan
 
 class Texture2D;
 
-/// \brief 2D texture array object class.
+/// 2D texture array object class.
 class Texture2DArray : public Texture
 {
 /// \name Construction
 /// \{
 public:
-	/// \brief Constructs a null instance.
+	/// Constructs a null instance.
 	Texture2DArray();
 
-	/// \brief Constructs a texture from an implementation
-	///
-	/// \param impl = The implementation
+	/** Constructs a texture from an implementation.
+	 *  \param impl The Texture object implementation.
+	 */
 	Texture2DArray(const std::shared_ptr<Texture_Impl> &impl) : Texture(impl) { }
 
-	/// \brief Constructs a Texture
-	///
-	/// \param context = Graphic Context
-	/// \param width = value
-	/// \param height = value
-	/// \param internal_format = Texture Format
-	/// \param levels = Mipmap levels for the texture. 0 = all levels
+	/** Constructs a new Texture object.
+	 *  \param context    Graphic context to construct the texture on.
+	 *  \param width      Width of the new texture.
+	 *  \param height     Height of the new texture.
+	 *  \param array_size Number of textures to allocate in this array.
+	 *  \param format     Data format of the new texture.
+	 *  \param levels     Number of mipmap levels for the new texture. Setting
+	 *                    this to `0` enables all levels.
+	 */
 	Texture2DArray(GraphicContext &context, int width, int height, int array_size, TextureFormat texture_format = tf_rgba8, int levels = 1);
 
-	/// \brief Constructs a Texture
-	///
-	/// \param context = Graphic Context
-	/// \param size = Size
-	/// \param internal_format = Texture Format
+	/** Constructs a new Texture object.
+	 *  \param context    Graphic context to construct the texture on.
+	 *  \param size       Size of the new texture.
+	 *  \param array_size Number of textures to allocate in this array.
+	 *  \param format     Data format of the new texture.
+	 *  \param levels     Number of mipmap levels for the new texture. Setting
+	 *                    this to `0` enables all levels.
+	 */
 	Texture2DArray(GraphicContext &context, const Size &size, int array_size, TextureFormat texture_format = tf_rgba8, int levels = 1);
 /// \}
 
 /// \name Attributes
 /// \{
 public:
-	/// \brief Get the texture width.
+	/// Retrieves the actual width of the texture in the display.
 	int get_width() const;
 
-	/// \brief Get the texture height.
+	/// Retrieves the actual height of the texture in the display.
 	int get_height() const;
 
-	/// \brief Get the texture size.
-	Size get_size() const;
+	/// Retrieves the actual size of the texture.
+	Size get_size() const { return Size{ get_width(), get_height() }; }
 
-	/// \brief Get the texture array size
+	/** Retrieves the pixel ratio of this texture.
+	 *  \return The display pixel ratio set for this texture.
+	 *          A NaN value implies that the texture should use the pixel ratio
+	 *          set in the DisplayWindowProvider.
+	 */
+	float get_pixel_ratio() const;
+
+	/// Returns the device independent width of this texture.
+	float get_dip_width() const { return get_width() / get_pixel_ratio(); }
+
+	/// Returns the device independent height of this texture.
+	float get_dip_height() const { return get_height() / get_pixel_ratio(); }
+
+	/// Returns the device independent size of this texture.
+	Sizef get_dip_size() const { return Sizef{ get_dip_width(), get_dip_height() }; }
+
+	/// Returns the number of textures in the array.
 	int get_array_size() const;
 
-	/// \brief Returns with texture width in device independent (96 DPI) pixels
-	float get_px_width() const { return get_width() * 96.0f / get_dpi(); }
-
-	/// \brief Returns with texture height in device independent (96 DPI) pixels
-	float get_px_height() const { return get_height() * 96.0f / get_dpi(); }
-
-	/// \brief Returns with texture size in device independent (96 DPI) pixels
-	Sizef get_px_size() const { return Sizef(get_px_width(), get_px_height()); }
-
-	/// \brief Physical pixels/dots per inch
-	float get_dpi() const;
-
-	/// \brief Get the texture wrap mode for the s coordinate.
+	/// Get the texture wrap mode for the s coordinate.
 	TextureWrapMode get_wrap_mode_s() const;
 
-	/// \brief Get the texture wrap mode for the t coordinate.
+	/// Get the texture wrap mode for the t coordinate.
 	TextureWrapMode get_wrap_mode_t() const;
 /// \}
 
 /// \name Operations
 /// \{
 public:
-	/// \brief Upload image to texture.
-	///
-	/// \param context Graphic context to use for the request
-	/// \param array_index Index in the array
-	/// \param image Image to upload.
-	/// \param level Mipmap level-of-detail number.
+	/** Upload image to this texture array.
+	 *  \param context     Graphic context to use for the request.
+	 *  \param array_index Index in the array to upload the image into.
+	 *  \param image       Image to upload.
+	 *  \param level       Mipmap level-of-detail number.
+	 */
 	void set_image(
 		GraphicContext &context,
 		int array_index,
 		const PixelBuffer &image,
 		int level = 0);
 
-	/// \brief Upload image to sub texture.
-	///
-	/// \param context Graphic context to use for the request
-	/// \param array_index Index in the array
-	/// \param image Image to upload.
-	/// \param level Mipmap level-of-detail number.
+	/** Upload image to sub-texture.
+	 *  \param context     Graphic context to use for the request.
+	 *  \param array_index Index in the array to upload the image into.
+	 *  \param x           The horizontal point in the selected texture to
+	 *                     write the new sub-texture image onto.
+	 *  \param y           The vertical point in the selected texture to write
+	 *                     the sub-texture image onto.
+	 *  \param image       Image to upload.
+	 *  \param level       Mipmap level-of-detail number.
+	 */
 	void set_subimage(
 		GraphicContext &context,
 		int array_index,
@@ -133,6 +146,15 @@ public:
 		const PixelBuffer &image,
 		const Rect &src_rect,
 		int level = 0);
+
+	/** Upload image to sub-texture.
+	 *  \param context     Graphic context to use for the request.
+	 *  \param array_index Index in the array to upload the image into.
+	 *  \param point       Point in the selected texture to write the new
+	 *                     sub-texture image onto.
+	 *  \param image       Image to upload.
+	 *  \param level       Mipmap level-of-detail number.
+	 */
 
 	void set_subimage(
 		GraphicContext &context,
@@ -146,12 +168,11 @@ public:
 		TextureWrapMode wrap_s,
 		TextureWrapMode wrap_t);
 
-	/// \brief Creates a 2D texture view
+	/// Creates a 2D texture view
 	Texture2D create_2d_view(int array_index, TextureFormat texture_format, int min_level, int num_levels);
 
-	/// \brief Sets the physical size for a pixel
-	/// \param dpi Pixels/dots per inch in both directions
-	void set_dpi(float dpi);
+	/// Sets the display pixel ratio for this texture.
+	void set_pixel_ratio(float ratio);
 /// \}
 };
 

--- a/Sources/API/Display/TargetProviders/display_window_provider.h
+++ b/Sources/API/Display/TargetProviders/display_window_provider.h
@@ -49,46 +49,46 @@ class InputContext;
 class CursorProvider;
 class CursorDescription;
 
-/// \brief Display Window site.
+/// Display Window site.
 class DisplayWindowSite
 {
 /// \name Attributes
 /// \{
 public:
-	/// \brief lost focus signal.
+	/// Lost focus signal.
 	Signal<void()> sig_lost_focus;
 
-	/// \brief got focus signal.
+	/// Obtained focus signal.
 	Signal<void()> sig_got_focus;
 
-	/// \brief resize signal.
+	/// Resize signal.
 	Signal<void(float, float)> sig_resize;
 
-	/// \brief paint signal.
+	/// Paint signal.
 	Signal<void(const Rectf &)> sig_paint;
 
-	/// \brief window close signal.
+	/// Window close signal.
 	Signal<void()> sig_window_close;
 
-	/// \brief window destroy signal.
+	/// Window destroy signal.
 	Signal<void()> sig_window_destroy;
 
-	/// \brief window minimized signal.
+	/// Window minimized signal.
 	Signal<void()> sig_window_minimized;
 
-	/// \brief window maximized signal.
+	/// Window maximized signal.
 	Signal<void()> sig_window_maximized;
 
-	/// \brief window restored signal.
+	/// Window restored signal.
 	Signal<void()> sig_window_restored;
 
-	/// \brief window resize callback function.
+	/// Window resize callback function.
 	std::function<void(Rectf &)> func_window_resize;
 
-	/// \brief minimized clicked callback function.
+	/// Minimize button is clicked callback function.
 	std::function<bool()> func_minimize_clicked;
 
-	/// \brief window moved signal.
+	/// Window moved signal.
 	Signal<void()> sig_window_moved;
 
 #ifdef WIN32
@@ -98,7 +98,7 @@ public:
 /// \}
 };
 
-/// \brief Interface for implementing a DisplayWindow target.
+/// Interface for implementing a DisplayWindow target.
 class DisplayWindowProvider
 {
 /// \name Construction
@@ -110,43 +110,52 @@ public:
 /// \name Attributes
 /// \{
 public:
-	/// \brief Returns the position and size of the window frame.
+	/// Returns the position and size of the window frame.
 	virtual Rect get_geometry() const = 0;
 
-	/// \brief Returns the drawable area of the window.
+	/// Returns the drawable area of the window.
 	virtual Rect get_viewport() const = 0;
 
-	/// \brief Physical pixels/dots per inch
-	virtual float get_dpi() const = 0;
+	/** Retrieves the number of physical pixels or dots per inch of the screen.
+	 *  \note DPI independence is a hard problem. On most platforms this value
+	 *        is fixed and will never change until either this application OR
+	 *        the operating system display manager is restarted.
+	 */
+	virtual float get_ppi() const = 0;
 
-	/// \brief Returns true if window has focus.
+	/** Returns the display pixel ratio of the window.
+	 *  \seealso Resolution Independence
+	 */
+	virtual float get_pixel_ratio() const = 0;
+
+	/// Returns true if window has focus.
 	virtual bool has_focus() const = 0;
 
-	/// \brief Returns true if the window is minimized.
+	/// Returns true if the window is minimized.
 	virtual bool is_minimized() const = 0;
 
-	/// \brief Returns true if the window is maximized.
+	/// Returns true if the window is maximized.
 	virtual bool is_maximized() const = 0;
 
-	/// \brief Returns true if the window is visible.
+	/// Returns true if the window is visible.
 	virtual bool is_visible() const = 0;
 
-	/// \brief Returns true if the window is fullscreen.
+	/// Returns true if the window is fullscreen.
 	virtual bool is_fullscreen() const = 0;
 
-	/// \brief Returns the minimum size of the window.
+	/// Returns the minimum size of the window.
 	virtual Size get_minimum_size(bool client_area) const = 0;
 
-	/// \brief Returns the maximum size of the window.
+	/// Returns the maximum size of the window.
 	virtual Size get_maximum_size(bool client_area) const = 0;
 
-	/// \brief Returns the maximum size of the window.
+	/// Returns the maximum size of the window.
 	virtual std::string get_title() const = 0;
 
-	/// \brief Return the graphic context for the window.
+	/// Returns the graphic context for the window.
 	virtual GraphicContext& get_gc() = 0;
 
-	/// \brief Return the input context for the window.
+	/// Returns the input context for the window.
 	virtual InputContext get_ic() = 0;
 
 	/** Returns an platform-specific internal display window handle object.
@@ -154,16 +163,16 @@ public:
 	 */
 	virtual DisplayWindowHandle const *get_handle() const = 0;
 
-	/// \brief Returns true if text is available in the clipboard.
+	/// Returns true if text is available in the clipboard.
 	virtual bool is_clipboard_text_available() const = 0;
 
-	/// \brief Returns true if an image is available in the clipboard.
+	/// Returns true if an image is available in the clipboard.
 	virtual bool is_clipboard_image_available() const = 0;
 
-	/// \brief Returns the text stored in the clipboard.
+	/// Returns the text stored in the clipboard.
 	virtual std::string get_clipboard_text() const = 0;
 
-	/// \brief Returns the image stored in the clipboard.
+	/// Returns the image stored in the clipboard.
 	virtual PixelBuffer get_clipboard_image() const = 0;
 
 /// \}
@@ -171,116 +180,129 @@ public:
 /// \{
 public:
 
-	/// \brief Convert from window client coordinates to screen coordinates.
+	/// Convert from window client coordinates to screen coordinates.
 	virtual Point client_to_screen(const Point &client) = 0;
 
-	/// \brief Convert from screen coordinates to client coordinates.
+	/// Convert from screen coordinates to client coordinates.
 	virtual Point screen_to_client(const Point &screen) = 0;
 
-	/// \brief Capture/Release the mouse.
+	/// Capture/Release the mouse.
 	virtual void capture_mouse(bool capture) = 0;
 
-	/// \brief Invalidates a region of a screen, causing a repaint.
+	/// Invalidates a region of a screen, causing a repaint.
 	virtual void request_repaint(const Rect &rect) = 0;
 
-	/// \brief Creates window, assigning site and description to provider.
+	/// Creates window, assigning site and description to provider.
 	virtual void create(DisplayWindowSite *site, const DisplayWindowDescription &description) = 0;
 
-	/// \brief Shows the mouse cursor.
+	/// Shows the mouse cursor.
 	virtual void show_system_cursor() = 0;
 
-	/// \brief Creates a new custom cursor.
+	/// Hides the mouse cursor.
+	virtual void hide_system_cursor() = 0;
+
+	/// Creates a new custom cursor.
 	virtual CursorProvider *create_cursor(const CursorDescription &cursor_description) = 0;
 
-	/// \brief Sets the current cursor icon.
+	/// Sets the current cursor icon.
 	virtual void set_cursor(CursorProvider *cursor) = 0;
 
-	/// \brief Sets the current cursor icon.
+	/// Sets the current cursor icon.
 	virtual void set_cursor(StandardCursor type) = 0;
 
 #ifdef WIN32
-	/// \brief Sets the current cursor handle (win32 only)
+	/// Sets the current cursor handle (win32 only)
 	virtual void set_cursor_handle(HCURSOR cursor) = 0;
 #endif
 
-	/// \brief Hides the mouse cursor.
-	virtual void hide_system_cursor() = 0;
-
-	/// \brief Change window title.
+	/// Change window title.
 	virtual void set_title(const std::string &new_title) = 0;
 
-	/// \brief Set window position and size.
+	/// Sets the position and size of this window on the screen.
 	virtual void set_position(const Rect &pos, bool client_area) = 0;
 
-	/// \brief Set size
-	///
-	/// \param width = value
-	/// \param height = value
-	/// \param client_area = bool
+	/** Sets the size of this window.
+	 *  \param width       Minimum width of the window.
+	 *  \param height      Minimum height of the window.
+	 *  \param client_area Size includes the entire window frame?
+	 */
 	virtual void set_size(int width, int height, bool client_area) = 0;
 
-	/// \brief Set minimum size
-	///
-	/// \param width = value
-	/// \param height = value
-	/// \param client_area = bool
+	/** Sets the minimum size allowed for this window when resizing.
+	 *  \param width       Minimum width of the window.
+	 *  \param height      Minimum height of the window.
+	 *  \param client_area Size includes the entire window frame?
+	 */
 	virtual void set_minimum_size(int width, int height, bool client_area) = 0;
 
-	/// \brief Set maximum size
-	///
-	/// \param width = value
-	/// \param height = value
-	/// \param client_area = bool
+	/** Sets the maximum size allowed for this window when resizing.
+	 *  \param width       Maximum width of the window.
+	 *  \param height      Maximum height of the window.
+	 *  \param client_area Size includes the entire window frame?
+	 */
 	virtual void set_maximum_size(int width, int height, bool client_area) = 0;
 
-	/// \brief Enables or disables a window.
+	/** Sets the display pixel ratio of this window.
+	 *  \param ratio The new display pixel ratio to use on this window.
+	 *               If a NaN floating point is supplied, ClanLib will
+	 *               use a value based on the current resolution of the
+	 *               screen.
+	 */
+	virtual void set_pixel_ratio(float ratio) = 0;
+
+	/// Enables or disables input into this window.
 	virtual void set_enabled(bool enable) = 0;
 
-	/// \brief Minimizes the window.
+	/// Minimizes the window.
 	virtual void minimize() = 0;
 
-	/// \brief Restores the window.
+	/// Restores the window.
 	virtual void restore() = 0;
 
-	/// \brief Maximizes the window.
+	/// Maximizes the window.
 	virtual void maximize() = 0;
 
-	/// \brief Displays the window in its current size and position.
+	/// Displays the window in its current size and position.
 	virtual void show(bool activate) = 0;
 
-	/// \brief Hides the window.
+	/// Hides the window.
 	virtual void hide() = 0;
 
-	/// \brief Raise window on top of other windows.
+	/// Raise window on top of other windows.
 	virtual void bring_to_front() = 0;
 
-	/// \brief Flip opengl buffers.
+	/// Flip the window display buffers.
 	virtual void flip(int interval) = 0;
 
-	/// \brief Copy a region of the backbuffer to the frontbuffer.
+	/// Copy a region of the backbuffer to the frontbuffer.
 	virtual void update(const Rect &rect) = 0;
 
-	/// \brief Stores text in the clipboard.
+	/// Stores text in the clipboard.
 	virtual void set_clipboard_text(const std::string &text) = 0;
 
-	/// \brief Stores an image in the clipboard.
+	/// Stores an image in the clipboard.
 	virtual void set_clipboard_image(const PixelBuffer &buf) = 0;
 
-	/// \brief Sets the large icon used for this window.
+	/// Sets the large icon used for this window.
 	virtual void set_large_icon(const PixelBuffer &image) = 0;
 
-	/// \brief Sets the small icon used for this window.
+	/// Sets the small icon used for this window.
 	virtual void set_small_icon(const PixelBuffer &image) = 0;
 
-	/// \brief Enable alpha channel for this window.
-	///
-	/// This is only supported on Windows Vista and above (Else use Layered windows instead)
-	/// \param blur_rect = Blur rectangle. If size = 0, then the entire window is used
+	/** Enable alpha channel blending for this window.
+	 *
+	 *  \note This is only supported on Windows Vista and above. You can use
+	 *        layered windows to achieve the same effect on systems that do
+	 *        not support this.
+	 *
+	 *  \param blur_rect Window blur area. If its size is `0`, the area of
+	 *                   the entire window will be used.
+	 */
 	virtual void enable_alpha_channel(const Rect &blur_rect) = 0;
 
-	/// \brief Exend the window frame into the client area
-	///
-	/// Only implemented on win32
+	/** Extend the window frame into the client area.
+	 *  \note This is only applicable in Windows.
+	 */
 	virtual void extend_frame_into_client_area(int left, int top, int right, int bottom) = 0;
 
 

--- a/Sources/API/Display/TargetProviders/graphic_context_provider.h
+++ b/Sources/API/Display/TargetProviders/graphic_context_provider.h
@@ -108,7 +108,10 @@ public:
 	virtual Size get_display_window_size() const = 0;
 
 	/// \brief Physical pixels/dots per inch
-	virtual float get_dpi() const = 0;
+	virtual float get_ppi() const = 0;
+
+	/// \brief Physical pixels/dots per inch
+	virtual float get_pixel_ratio() const = 0;
 
 	/// \brief Get the window resized signal
 	virtual Signal<void(const Size &)> &sig_window_resized() = 0;
@@ -127,7 +130,7 @@ public:
 
 	/// \brief Returns the Y axis direction for viewports, clipping rects, textures and render targets
 	virtual TextureImageYAxis get_texture_image_y_axis() const = 0;
-	
+
 	/// \brief Returns the shader language used
 	virtual ShaderLanguage get_shader_language() const = 0;
 
@@ -145,7 +148,7 @@ public:
 
 	/// \brief Returns true if the hardware supports compute shaders
 	///
-	/// This always returns true for OpenGL 4.3 or newer, or Direct3D 11.0 or newer. 
+	/// This always returns true for OpenGL 4.3 or newer, or Direct3D 11.0 or newer.
 	/// For Direct3D 10.0 and 10.1 the support for compute shaders is optional.
 	virtual bool has_compute_shader_support() const = 0;
 

--- a/Sources/Display/2D/canvas.cpp
+++ b/Sources/Display/2D/canvas.cpp
@@ -674,10 +674,10 @@ void Canvas::fill_ellipse(const Pointf &center, float radius_x, float radius_y, 
 
 Pointf Canvas::grid_fit(const Pointf &pos)
 {
-	float dpi_scale = get_gc().get_dpi() / 96.0f;
+	float pixel_ratio = get_gc().get_pixel_ratio();
 	Vec4f world_pos = get_transform() * Vec4f(pos.x, pos.y, 0.0f, 1.0f);
-	world_pos.x = std::round(world_pos.x * dpi_scale) / dpi_scale;
-	world_pos.y = std::round(world_pos.y * dpi_scale) / dpi_scale;
+	world_pos.x = std::round(world_pos.x * pixel_ratio) / pixel_ratio;
+	world_pos.y = std::round(world_pos.y * pixel_ratio) / pixel_ratio;
 	Vec4f object_pos = get_inverse_transform() * world_pos;
 	return Pointf(object_pos.x, object_pos.y);
 }

--- a/Sources/Display/2D/canvas_batcher.cpp
+++ b/Sources/Display/2D/canvas_batcher.cpp
@@ -130,7 +130,7 @@ void CanvasBatcher_Impl::update_batcher_matrix(GraphicContext &gc, const Mat4f &
 
 	if (active_batcher)
 	{
-		active_batcher->matrix_changed(modelview, projection, image_yaxis, gc.get_dpi());
+		active_batcher->matrix_changed(modelview, projection, image_yaxis, gc.get_pixel_ratio());
 	}
 }
 

--- a/Sources/Display/2D/canvas_impl.h
+++ b/Sources/Display/2D/canvas_impl.h
@@ -66,8 +66,8 @@ public:
 	void pop_cliprect();
 	void reset_cliprect();
 
-	GraphicContext get_gc() const {return gc;}
-	GraphicContext& get_gc() {return gc;}
+	GraphicContext get_gc() const { return gc; }
+	GraphicContext& get_gc() { return gc; }
 
 	void set_transform(const Mat4f &matrix);
 	const Mat4f &get_transform() const;

--- a/Sources/Display/2D/image.cpp
+++ b/Sources/Display/2D/image.cpp
@@ -108,8 +108,9 @@ void Image_Impl::calc_hotspot()
 			break;
 	}
 
-	translated_hotspot.x *= 96.0f / texture.get_dpi();
-	translated_hotspot.y *= 96.0f / texture.get_dpi();
+	// TODO Test get_pixel_ratio();
+	translated_hotspot.x /= texture.get_pixel_ratio();
+	translated_hotspot.y /= texture.get_pixel_ratio();
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -223,12 +224,12 @@ void Image::get_alignment(Origin &origin, float &x, float &y) const
 
 float Image::get_width() const
 {
-	return impl->texture_rect.get_width() * 96.0f / impl->texture.get_dpi();
+	return impl->texture_rect.get_width() / impl->texture.get_pixel_ratio();
 }
 
 float Image::get_height() const
 {
-	return impl->texture_rect.get_height() * 96.0f / impl->texture.get_dpi();
+	return impl->texture_rect.get_height() / impl->texture.get_pixel_ratio();
 }
 
 Sizef Image::get_size() const
@@ -242,7 +243,7 @@ Sizef Image::get_size() const
 void Image::draw(Canvas &canvas, float x, float y) const
 {
 	Rectf dest(
-		x + impl->translated_hotspot.x, y + impl->translated_hotspot.y, 
+		x + impl->translated_hotspot.x, y + impl->translated_hotspot.y,
 		Sizef(get_width() * impl->scale_x, get_height() * impl->scale_y));
 
 	RenderBatchTriangle *batcher = canvas.impl->batcher.get_triangle_batcher();

--- a/Sources/Display/2D/render_batch_line.cpp
+++ b/Sources/Display/2D/render_batch_line.cpp
@@ -135,7 +135,7 @@ void RenderBatchLine::flush(GraphicContext &gc)
 	}
 }
 
-void RenderBatchLine::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float dpi)
+void RenderBatchLine::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float pixel_ratio)
 {
 	modelview_projection_matrix = new_projection * new_modelview;
 }

--- a/Sources/Display/2D/render_batch_line.h
+++ b/Sources/Display/2D/render_batch_line.h
@@ -55,7 +55,7 @@ private:
 	inline Vec4f to_position(float x, float y) const;
 	void set_batcher_active(Canvas &canvas, int num_vertices);
 	void flush(GraphicContext &gc) override;
-	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float dpi) override;
+	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float pixel_ratio) override;
 
 	enum { max_vertices = RenderBatchBuffer::vertex_buffer_size / sizeof(LineVertex) };
 	LineVertex *vertices;

--- a/Sources/Display/2D/render_batch_line_texture.cpp
+++ b/Sources/Display/2D/render_batch_line_texture.cpp
@@ -128,7 +128,7 @@ void RenderBatchLineTexture::flush(GraphicContext &gc)
 
 }
 
-void RenderBatchLineTexture::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float dpi)
+void RenderBatchLineTexture::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float pixel_ratio)
 {
 	modelview_projection_matrix = new_projection * new_modelview;
 }

--- a/Sources/Display/2D/render_batch_line_texture.h
+++ b/Sources/Display/2D/render_batch_line_texture.h
@@ -55,7 +55,7 @@ private:
 	inline Vec4f to_position(float x, float y) const;
 	void set_batcher_active(Canvas &canvas, int num_vertices, const Texture2D &texture);
 	void flush(GraphicContext &gc) override;
-	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float dpi) override;
+	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float pixel_ratio) override;
 
 	enum { max_vertices = RenderBatchBuffer::vertex_buffer_size / sizeof(LineTextureVertex) };
 	LineTextureVertex *vertices;

--- a/Sources/Display/2D/render_batch_path.cpp
+++ b/Sources/Display/2D/render_batch_path.cpp
@@ -72,11 +72,11 @@ namespace clan
 		fill_renderer.flush(gc);
 	}
 
-	void RenderBatchPath::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float dpi)
+	void RenderBatchPath::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float pixel_ratio)
 	{
 		// We ignore the projection
 		fill_renderer.set_yaxis(image_yaxis);
-		modelview_matrix = Mat4f::scale(dpi / 96.0f, dpi / 96.0f, 1.0f) * new_modelview;
+		modelview_matrix = Mat4f::scale(pixel_ratio, pixel_ratio, 1.0f) * new_modelview;
 	}
 
 	void RenderBatchPath::render(const Path &path, PathRenderer *path_renderer)

--- a/Sources/Display/2D/render_batch_path.h
+++ b/Sources/Display/2D/render_batch_path.h
@@ -59,7 +59,7 @@ private:
 
 	int set_batcher_active(Canvas &canvas);
 	void flush(GraphicContext &gc) override;
-	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float dpi) override;
+	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float pixel_ratio) override;
 
 	inline Pointf to_position(const clan::Pointf &point) const;
 

--- a/Sources/Display/2D/render_batch_point.cpp
+++ b/Sources/Display/2D/render_batch_point.cpp
@@ -102,7 +102,7 @@ void RenderBatchPoint::flush(GraphicContext &gc)
 	}
 }
 
-void RenderBatchPoint::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float dpi)
+void RenderBatchPoint::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float pixel_ratio)
 {
 	modelview_projection_matrix = new_projection * new_modelview;
 }

--- a/Sources/Display/2D/render_batch_point.h
+++ b/Sources/Display/2D/render_batch_point.h
@@ -54,8 +54,8 @@ private:
 	inline Vec4f to_position(float x, float y) const;
 	void set_batcher_active(Canvas &canvas, int num_vertices);
 	void flush(GraphicContext &gc) override;
-	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float dpi) override;
-	
+	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float pixel_ratio) override;
+
 	enum { max_vertices = RenderBatchBuffer::vertex_buffer_size / sizeof(PointVertex) };
 	PointVertex *vertices;
 	RenderBatchBuffer *batch_buffer;

--- a/Sources/Display/2D/render_batch_triangle.cpp
+++ b/Sources/Display/2D/render_batch_triangle.cpp
@@ -366,7 +366,7 @@ void RenderBatchTriangle::flush(GraphicContext &gc)
 	}
 }
 
-void RenderBatchTriangle::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float dpi)
+void RenderBatchTriangle::matrix_changed(const Mat4f &new_modelview, const Mat4f &new_projection, TextureImageYAxis image_yaxis, float pixel_ratio)
 {
 	modelview_projection_matrix = new_projection * new_modelview;
 }

--- a/Sources/Display/2D/render_batch_triangle.h
+++ b/Sources/Display/2D/render_batch_triangle.h
@@ -73,7 +73,7 @@ private:
 	int set_batcher_active(Canvas &canvas);
 	int set_batcher_active(Canvas &canvas, int num_vertices);
 	void flush(GraphicContext &gc) override;
-	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float dpi) override;
+	void matrix_changed(const Mat4f &modelview, const Mat4f &projection, TextureImageYAxis image_yaxis, float pixel_ratio) override;
 
 	inline void to_sprite_vertex(const Pointf &texture_position, const Pointf &dest_position, RenderBatchTriangle::SpriteVertex &v, int texindex, const Colorf &color) const;
 	inline Vec4f to_position(float x, float y) const;

--- a/Sources/Display/Font/FontEngine/font_engine_win32.h
+++ b/Sources/Display/Font/FontEngine/font_engine_win32.h
@@ -72,37 +72,37 @@ private:
 
 	struct ttf_offset_table
 	{
-		ttf_version version;	// Fixed sfnt version 0x00010000 for version 1.0. 
-		USHORT numTables;	// Number of tables. 
-		USHORT searchRange;	// (Maximum power of 2 <= numTables) x 16. 
-		USHORT entrySelector;	// Log2(maximum power of 2 <= numTables). 
-		USHORT rangeShift;	// NumTables x 16-searchRange. 
+		ttf_version version;	// Fixed sfnt version 0x00010000 for version 1.0.
+		USHORT numTables;	// Number of tables.
+		USHORT searchRange;	// (Maximum power of 2 <= numTables) x 16.
+		USHORT entrySelector;	// Log2(maximum power of 2 <= numTables).
+		USHORT rangeShift;	// NumTables x 16-searchRange.
 	};
 
 	struct ttf_table_record
 	{
-		char tag[4];	// 4 -byte identifier. 
-		ULONG checkSum;	// CheckSum for this table. 
-		ULONG offset;	// Offset from beginning of TrueType font file. 
-		ULONG length;	// Length of this table. 
+		char tag[4];	// 4 -byte identifier.
+		ULONG checkSum;	// CheckSum for this table.
+		ULONG offset;	// Offset from beginning of TrueType font file.
+		ULONG length;	// Length of this table.
 	};
 
 	struct ttf_naming_table
 	{
-		USHORT format;	// Format selector (=0). 
-		USHORT count;	// Number of name records. 
-		USHORT stringOffset;	// Offset to start of string storage (from start of table). 
-		// NameRecord nameRecord[count] The name records where count is the number of records. 
+		USHORT format;	// Format selector (=0).
+		USHORT count;	// Number of name records.
+		USHORT stringOffset;	// Offset to start of string storage (from start of table).
+		// NameRecord nameRecord[count] The name records where count is the number of records.
 	};
 
 	struct ttf_naming_record
 	{
-		USHORT platformID;	// Platform ID. 
-		USHORT encodingID;	// Platform-specific encoding ID. 
-		USHORT languageID;	// Language ID. 
-		USHORT nameID;		// Name ID. 
-		USHORT length;		// String length (in bytes). 
-		USHORT offset;		// String offset from start of storage area (in bytes). 
+		USHORT platformID;	// Platform ID.
+		USHORT encodingID;	// Platform-specific encoding ID.
+		USHORT languageID;	// Language ID.
+		USHORT nameID;		// Name ID.
+		USHORT length;		// String length (in bytes).
+		USHORT offset;		// String offset from start of storage area (in bytes).
 	};
 
 	// Swap the endians
@@ -134,7 +134,9 @@ private:
 	DataBuffer data_buffer;
 	FontDescription font_description;
 	FontMetrics font_metrics;
-	float dpi = 96.0f;
+
+	float ppi           = 96.0f;
+	float pixel_ratio   = std::nan("");
 };
 
 }

--- a/Sources/Display/Image/pixel_buffer.cpp
+++ b/Sources/Display/Image/pixel_buffer.cpp
@@ -113,11 +113,6 @@ bool PixelBuffer::is_gpu() const
 	return impl->provider->is_gpu();
 }
 
-Size PixelBuffer::get_size() const
-{
-	return impl->provider->get_size();
-}
-
 int PixelBuffer::get_pitch() const
 {
 	return impl->provider->get_pitch();
@@ -293,17 +288,17 @@ Colorf PixelBuffer::get_pixel(int x, int y)
 	return impl->get_pixel(x,y);
 }
 
-float PixelBuffer::get_dpi() const
+float PixelBuffer::get_pixel_ratio() const
 {
-	return impl->dpi;
+	return impl->pixel_ratio;
 }
 
 /////////////////////////////////////////////////////////////////////////////
 // PixelBuffer operations:
 
-void PixelBuffer::set_dpi(float dpi)
+void PixelBuffer::set_pixel_ratio(float ratio)
 {
-	impl->dpi = dpi;
+	impl->pixel_ratio = ratio;
 }
 
 void PixelBuffer::lock(GraphicContext &gc, BufferAccess access)

--- a/Sources/Display/Image/pixel_buffer_impl.cpp
+++ b/Sources/Display/Image/pixel_buffer_impl.cpp
@@ -36,15 +36,6 @@
 #include "API/Display/TargetProviders/graphic_context_provider.h"
 #include "API/Display/TargetProviders/pixel_buffer_provider.h"
 #include "API/Display/Image/pixel_converter.h"
-#include <emmintrin.h>
-
-#ifndef WIN32
-#include <cstdlib>
-#endif
-
-#ifdef __MINGW32__
-#include <malloc.h>
-#endif
 
 namespace clan
 {

--- a/Sources/Display/Image/pixel_buffer_impl.h
+++ b/Sources/Display/Image/pixel_buffer_impl.h
@@ -60,7 +60,7 @@ public:
 
 	PixelBufferProvider *provider;
 
-	float dpi = 96.0f;
+	float pixel_ratio = std::nan("");
 
 /// \}
 /// \name Attributes

--- a/Sources/Display/Render/graphic_context.cpp
+++ b/Sources/Display/Render/graphic_context.cpp
@@ -42,7 +42,7 @@
 #include "API/Core/Math/angle.h"
 #include "primitives_array_impl.h"
 #include "graphic_context_impl.h"
-#include "API/Display/Render/shared_gc_data.h" 
+#include "API/Display/Render/shared_gc_data.h"
 #include "API/Display/Render/depth_stencil_state_description.h"
 #include "API/Display/Render/blend_state_description.h"
 #include "API/Display/Render/rasterizer_state_description.h"
@@ -179,9 +179,14 @@ Size GraphicContext::get_size() const
 	return impl->get_size();
 }
 
-float GraphicContext::get_dpi() const
+float GraphicContext::get_ppi() const
 {
-	return impl->graphic_screen->get_provider()->get_dpi();
+	return impl->graphic_screen->get_provider()->get_ppi();
+}
+
+float GraphicContext::get_pixel_ratio() const
+{
+	return impl->graphic_screen->get_provider()->get_pixel_ratio();
 }
 
 Size GraphicContext::get_max_texture_size() const

--- a/Sources/Display/Render/texture_2d.cpp
+++ b/Sources/Display/Render/texture_2d.cpp
@@ -94,14 +94,14 @@ Texture2D::Texture2D(GraphicContext &context, const std::string &fullname, const
 	*this = Texture2D(context, filename, vfs, import_desc );
 }
 
-Texture2D::Texture2D( GraphicContext &context, const std::string &filename, const FileSystem &fs, const ImageImportDescription &import_desc)
+Texture2D::Texture2D(GraphicContext &context, const std::string &filename, const FileSystem &fs, const ImageImportDescription &import_desc)
 {
 	PixelBuffer pb = ImageProviderFactory::load(filename, fs, std::string());
 	pb = import_desc.process(pb);
 
 	*this = Texture2D(context, pb.get_width(), pb.get_height(), import_desc.is_srgb() ? tf_srgb8_alpha8 : tf_rgba8);
 
-	set_dpi(pb.get_dpi());
+	set_pixel_ratio(pb.get_pixel_ratio());
 	set_subimage(context, Point(0, 0), pb, Rect(pb.get_size()), 0);
 
 	impl->provider->set_wrap_mode(impl->wrap_mode_s, impl->wrap_mode_t);
@@ -113,7 +113,7 @@ Texture2D::Texture2D(GraphicContext &context, IODevice &file, const std::string 
 	pb = import_desc.process(pb);
 	*this = Texture2D(context, pb.get_width(), pb.get_height(), import_desc.is_srgb() ? tf_srgb8_alpha8 : tf_rgba8);
 
-	set_dpi(pb.get_dpi());
+	set_pixel_ratio(pb.get_pixel_ratio());
 	set_subimage(context, Point(0, 0), pb, Rect(pb.get_size()), 0);
 
 	impl->provider->set_wrap_mode(impl->wrap_mode_s, impl->wrap_mode_t);
@@ -128,7 +128,7 @@ Texture2D::Texture2D(GraphicContext &context, const PixelBuffer &image, const Re
 {
 	*this = Texture2D(context, src_rect.get_width(), src_rect.get_height(), is_srgb ? tf_srgb8_alpha8 : tf_rgba8);
 
-	set_dpi(image.get_dpi());
+	set_pixel_ratio(image.get_pixel_ratio());
 	set_subimage(context, Point(0, 0), image, src_rect, 0);
 
 	impl->provider->set_wrap_mode(impl->wrap_mode_s, impl->wrap_mode_t);
@@ -144,15 +144,9 @@ int Texture2D::get_height() const
 	return impl->height;
 }
 
-Size Texture2D::get_size() const
-{
-	return Size(impl->width, impl->height);
-}
-
 PixelBuffer Texture2D::get_pixeldata(GraphicContext &gc, int level) const
 {
-	// todo: pixel format rgba8888?
-	return impl->provider->get_pixeldata(gc, tf_rgba8, level); 
+	return impl->provider->get_pixeldata(gc, tf_rgba8, level);
 }
 
 PixelBuffer Texture2D::get_pixeldata(GraphicContext &gc, TextureFormat texture_format, int level) const
@@ -220,14 +214,14 @@ void Texture2D::set_wrap_mode(TextureWrapMode wrap_s, TextureWrapMode wrap_t)
 	}
 }
 
-float Texture2D::get_dpi() const
+float Texture2D::get_pixel_ratio() const
 {
-	return impl->dpi;
+	return impl->pixel_ratio;
 }
 
-void Texture2D::set_dpi(float dpi)
+void Texture2D::set_pixel_ratio(float ratio)
 {
-	impl->dpi = dpi;
+	impl->pixel_ratio = ratio;
 }
 
 }

--- a/Sources/Display/Render/texture_2d_array.cpp
+++ b/Sources/Display/Render/texture_2d_array.cpp
@@ -84,11 +84,6 @@ int Texture2DArray::get_height() const
 	return impl->height;
 }
 
-Size Texture2DArray::get_size() const
-{
-	return Size(impl->width, impl->height);
-}
-
 int Texture2DArray::get_array_size() const
 {
 	return impl->array_size;
@@ -140,14 +135,14 @@ Texture2D Texture2DArray::create_2d_view(int array_index, TextureFormat texture_
 	return view.to_texture_2d();
 }
 
-float Texture2DArray::get_dpi() const
+float Texture2DArray::get_pixel_ratio() const
 {
-	return impl->dpi;
+	return impl->pixel_ratio;
 }
 
-void Texture2DArray::set_dpi(float dpi)
+void Texture2DArray::set_pixel_ratio(float ratio)
 {
-	impl->dpi = dpi;
+	impl->pixel_ratio = ratio;
 }
 
 }

--- a/Sources/Display/Render/texture_impl.h
+++ b/Sources/Display/Render/texture_impl.h
@@ -91,7 +91,7 @@ public:
 	TextureCompareMode compare_mode;
 	CompareFunction compare_function;
 
-	float dpi = 96.0f;
+	float pixel_ratio = std::nan("");
 
 private:
 

--- a/Sources/Display/Resources/XML/image_xml.cpp
+++ b/Sources/Display/Resources/XML/image_xml.cpp
@@ -64,11 +64,11 @@ Image Image::load(Canvas &canvas, const std::string &id, const XMLResourceDocume
 			Texture2D texture = Texture2D(canvas, PathHelp::combine(resource.get_base_path(), image_name), resource.get_file_system());
 
 			DomNode cur_child(cur_element.get_first_child());
-			if(cur_child.is_null()) 
+			if(cur_child.is_null())
 			{
 				image = Image(texture, texture.get_size());
 			}
-			else 
+			else
 			{
 				do {
 					DomElement cur_child_elemnt = cur_child.to_element();
@@ -169,8 +169,9 @@ Image Image::load(Canvas &canvas, const std::string &id, const XMLResourceDocume
 			int xoffset = StringHelp::text_to_int(cur_element.get_attribute("x", "0"));
 			int yoffset = StringHelp::text_to_int(cur_element.get_attribute("y", "0"));
 
-			xoffset *= 96.0f / image.get_texture().get_texture().get_dpi();
-			yoffset *= 96.0f / image.get_texture().get_texture().get_dpi();
+			// TODO Find out what is going on here...
+			xoffset /= image.get_texture().get_texture().get_pixel_ratio();
+			yoffset /= image.get_texture().get_texture().get_pixel_ratio();
 
 			image.set_alignment(origin, xoffset, yoffset);
 		}

--- a/Sources/Display/Win32/input_device_provider_win32mouse.cpp
+++ b/Sources/Display/Win32/input_device_provider_win32mouse.cpp
@@ -65,7 +65,7 @@ float InputDeviceProvider_Win32Mouse::get_x() const
 	BOOL res = ScreenToClient(window->get_hwnd(), &cursor_pos);
 	if (res == FALSE) return 0;
 
-	return cursor_pos.x * 96.0f / window->get_dpi();
+	return cursor_pos.x / window->get_pixel_ratio();
 }
 
 float InputDeviceProvider_Win32Mouse::get_y() const
@@ -77,7 +77,7 @@ float InputDeviceProvider_Win32Mouse::get_y() const
 	BOOL res = ScreenToClient(window->get_hwnd(), &cursor_pos);
 	if (res == FALSE) return 0;
 
-	return cursor_pos.y * 96.0f / window->get_dpi();
+	return cursor_pos.y / window->get_pixel_ratio();
 }
 
 bool InputDeviceProvider_Win32Mouse::get_keycode(int keycode) const
@@ -139,9 +139,9 @@ void InputDeviceProvider_Win32Mouse::set_position(float x, float y)
 {
 	throw_if_disposed();
 	POINT pt;
-	pt.x = (int)std::round(x * window->get_dpi() / 96.0f);
-	pt.y = (int)std::round(y * window->get_dpi() / 96.0f);
-	
+	pt.x = (int)std::round(x * window->get_pixel_ratio());
+	pt.y = (int)std::round(y * window->get_pixel_ratio());
+
 	ClientToScreen(window->get_hwnd(), &pt);
 	SetCursorPos(pt.x, pt.y);
 }

--- a/Sources/Display/Win32/input_device_provider_win32tablet.cpp
+++ b/Sources/Display/Win32/input_device_provider_win32tablet.cpp
@@ -44,7 +44,7 @@ namespace clan
 
 InputDeviceProvider_Win32Tablet::InputDeviceProvider_Win32Tablet(Win32Window *window)
 : InputDeviceProvider(),
-  sig_provider_event(0), 
+  sig_provider_event(0),
   window(window),
   htab(0),
   wintab_dll(0),
@@ -288,7 +288,7 @@ void InputDeviceProvider_Win32Tablet::init_axis()
 }
 
 BOOL InputDeviceProvider_Win32Tablet::process_packet(WPARAM wParam, LPARAM lParam)
-{	 
+{
 	WINDOWINFO winfo; // todo: updating this info could probably be connected to some window move signal
 	memset(&winfo, 0, sizeof(WINDOWINFO));
 	winfo.cbSize = sizeof(WINDOWINFO);
@@ -324,7 +324,7 @@ BOOL InputDeviceProvider_Win32Tablet::process_packet(WPARAM wParam, LPARAM lPara
 				e.id = tablet_key;
 				e.id_offset = keycode;
 				e.type         = InputEvent::pressed;
-				e.mouse_pos    = Pointf((pkt.pkX - winfo.rcClient.left) * 96.0f / window->get_dpi(), (pkt.pkY - winfo.rcClient.top) * 96.0f / window->get_dpi());
+				e.mouse_pos    = Pointf((pkt.pkX - winfo.rcClient.left) / window->get_pixel_ratio(), (pkt.pkY - winfo.rcClient.top) / window->get_pixel_ratio());
 				e.axis_pos     = 0;
 				e.repeat_count = 0;
 				window->set_modifier_keys(e);
@@ -340,7 +340,7 @@ BOOL InputDeviceProvider_Win32Tablet::process_packet(WPARAM wParam, LPARAM lPara
 				e.id = tablet_key;
 				e.id_offset = keycode;
 				e.type         = InputEvent::released;
-				e.mouse_pos    = Pointf((pkt.pkX - winfo.rcClient.left) * 96.0f / window->get_dpi(), (pkt.pkY - winfo.rcClient.top) * 96.0f / window->get_dpi());
+				e.mouse_pos    = Pointf((pkt.pkX - winfo.rcClient.left) / window->get_pixel_ratio(), (pkt.pkY - winfo.rcClient.top) / window->get_pixel_ratio());
 				e.axis_pos     = 0;
 				e.repeat_count = 0;
 				window->set_modifier_keys(e);
@@ -353,7 +353,7 @@ BOOL InputDeviceProvider_Win32Tablet::process_packet(WPARAM wParam, LPARAM lPara
 
 				e.id           = tablet_z_axis; // TODO: support tilt, rotation.
 				e.type         = InputEvent::axis_moved; // x,y as pointer movements
-				e.mouse_pos    = Pointf((pkt.pkX - winfo.rcClient.left) * 96.0f / window->get_dpi(), (pkt.pkY - winfo.rcClient.top) * 96.0f / window->get_dpi());
+				e.mouse_pos    = Pointf((pkt.pkX - winfo.rcClient.left) / window->get_pixel_ratio(), (pkt.pkY - winfo.rcClient.top) / window->get_pixel_ratio());
 				e.axis_pos     = get_axis(2);
 				e.repeat_count = 0;
 				window->set_modifier_keys(e);

--- a/Sources/Display/Win32/screen_info_provider_win32.cpp
+++ b/Sources/Display/Win32/screen_info_provider_win32.cpp
@@ -48,7 +48,7 @@ ScreenInfoProvider_Win32::ScreenInfoProvider_Win32()
 std::vector<Rectf> ScreenInfoProvider_Win32::get_screen_geometries(int &primary_screen_index) const
 {
 	HDC dc = GetDC(0);
-	int dpi = GetDeviceCaps(dc, LOGPIXELSX);
+	int ppi = GetDeviceCaps(dc, LOGPIXELSX);
 	ReleaseDC(0, dc);
 
 	std::vector<Rectf> monitor_positions;
@@ -79,10 +79,10 @@ std::vector<Rectf> ScreenInfoProvider_Win32::get_screen_geometries(int &primary_
 						primary_screen_index = monitor_positions.size();
 
 					Rectf pos(
-						devmode.dmPosition.x * 96.0f / dpi,
-						devmode.dmPosition.y * 96.0f / dpi,
-						(devmode.dmPosition.x + devmode.dmPelsWidth) * 96.0f / dpi,
-						(devmode.dmPosition.y + devmode.dmPelsHeight) * 96.0f / dpi);
+						devmode.dmPosition.x * 96.0f / ppi,
+						devmode.dmPosition.y * 96.0f / ppi,
+						(devmode.dmPosition.x + devmode.dmPelsWidth) * 96.0f / ppi,
+						(devmode.dmPosition.y + devmode.dmPelsHeight) * 96.0f / ppi);
 					monitor_positions.push_back(pos);
 				}
 			}

--- a/Sources/Display/Win32/win32_window.h
+++ b/Sources/Display/Win32/win32_window.h
@@ -70,7 +70,8 @@ public:
 	HWND get_hwnd() const { return hwnd; }
 	Rect get_geometry() const;
 	Rect get_viewport() const;
-	float get_dpi() const { return dpi; }
+	float get_ppi() const { return ppi; }
+	float get_pixel_ratio() const { return pixel_ratio; }
 	bool has_focus() const;
 	bool is_minimized() const;
 	bool is_maximized() const;
@@ -109,6 +110,9 @@ public:
 	void set_size(int width, int height, bool client_area);
 	void set_minimum_size(int width, int height, bool client_area);
 	void set_maximum_size(int width, int height, bool client_area);
+
+	void set_pixel_ratio(float ratio);
+
 	void minimize();
 	void restore();
 	void maximize();
@@ -230,7 +234,8 @@ private:
 	HRGN update_window_region;
 	unsigned int update_window_max_region_rects;
 
-	float dpi = 96.0f;
+	float ppi           = 96.0f;
+	float pixel_ratio   = std::nan("");
 };
 
 }

--- a/Sources/Display/Window/display_window.cpp
+++ b/Sources/Display/Window/display_window.cpp
@@ -125,10 +125,10 @@ Rectf DisplayWindow::get_geometry() const
 {
 	Rect geometryi = impl->provider->get_geometry();
 	Rectf geometry;
-	geometry.left = geometryi.left * 96.0f / impl->provider->get_dpi();
-	geometry.top = geometryi.top * 96.0f / impl->provider->get_dpi();
-	geometry.right = geometryi.right * 96.0f / impl->provider->get_dpi();
-	geometry.bottom = geometryi.bottom * 96.0f / impl->provider->get_dpi();
+	geometry.left = geometryi.left / impl->provider->get_pixel_ratio();
+	geometry.top = geometryi.top / impl->provider->get_pixel_ratio();
+	geometry.right = geometryi.right / impl->provider->get_pixel_ratio();
+	geometry.bottom = geometryi.bottom / impl->provider->get_pixel_ratio();
 	return geometry;
 }
 
@@ -136,10 +136,10 @@ Rectf DisplayWindow::get_viewport() const
 {
 	Rect viewporti = impl->provider->get_viewport();
 	Rectf viewport;
-	viewport.left = viewporti.left * 96.0f / impl->provider->get_dpi();
-	viewport.top = viewporti.top * 96.0f / impl->provider->get_dpi();
-	viewport.right = viewporti.right * 96.0f / impl->provider->get_dpi();
-	viewport.bottom = viewporti.bottom * 96.0f / impl->provider->get_dpi();
+	viewport.left = viewporti.left / impl->provider->get_pixel_ratio();
+	viewport.top = viewporti.top / impl->provider->get_pixel_ratio();
+	viewport.right = viewporti.right / impl->provider->get_pixel_ratio();
+	viewport.bottom = viewporti.bottom / impl->provider->get_pixel_ratio();
 	return viewport;
 }
 
@@ -288,8 +288,8 @@ Sizef DisplayWindow::get_minimum_size( bool client_area )
 {
 	Size sizei = impl->provider->get_minimum_size(client_area);
 	Sizef sizef;
-	sizef.width = sizei.width * 96.0f / impl->provider->get_dpi();
-	sizef.height = sizei.height * 96.0f / impl->provider->get_dpi();
+	sizef.width = sizei.width / impl->provider->get_pixel_ratio();
+	sizef.height = sizei.height / impl->provider->get_pixel_ratio();
 	return sizef;
 }
 
@@ -297,8 +297,8 @@ Sizef DisplayWindow::get_maximum_size( bool client_area )
 {
 	Size sizei = impl->provider->get_maximum_size(client_area);
 	Sizef sizef;
-	sizef.width = sizei.width * 96.0f / impl->provider->get_dpi();
-	sizef.height = sizei.height * 96.0f / impl->provider->get_dpi();
+	sizef.width = sizei.width / impl->provider->get_pixel_ratio();
+	sizef.height = sizei.height / impl->provider->get_pixel_ratio();
 	return sizef;
 }
 
@@ -320,24 +320,24 @@ void DisplayWindow::set_cursor_handle(HCURSOR cursor)
 Pointf DisplayWindow::client_to_screen(const Pointf &client)
 {
 	Point clienti;
-	clienti.x = (int)std::round(client.x * impl->provider->get_dpi() / 96.0f);
-	clienti.y = (int)std::round(client.y * impl->provider->get_dpi() / 96.0f);
+	clienti.x = (int)std::round(client.x * impl->provider->get_pixel_ratio());
+	clienti.y = (int)std::round(client.y * impl->provider->get_pixel_ratio());
 	Point screeni = impl->provider->client_to_screen(clienti);
 	Pointf screen;
-	screen.x = screeni.x * 96.0f / impl->provider->get_dpi();
-	screen.y = screeni.y * 96.0f / impl->provider->get_dpi();
+	screen.x = screeni.x / impl->provider->get_pixel_ratio();
+	screen.y = screeni.y / impl->provider->get_pixel_ratio();
 	return screen;
 }
 
 Pointf DisplayWindow::screen_to_client(const Pointf &screen)
 {
 	Point screeni;
-	screeni.x = (int)std::round(screen.x * impl->provider->get_dpi() / 96.0f);
-	screeni.y = (int)std::round(screen.y * impl->provider->get_dpi() / 96.0f);
+	screeni.x = (int)std::round(screen.x * impl->provider->get_pixel_ratio());
+	screeni.y = (int)std::round(screen.y * impl->provider->get_pixel_ratio());
 	Point clienti = impl->provider->screen_to_client(screeni);
 	Pointf client;
-	client.x = clienti.x * 96.0f / impl->provider->get_dpi();
-	client.y = clienti.y * 96.0f / impl->provider->get_dpi();
+	client.x = clienti.x / impl->provider->get_pixel_ratio();
+	client.y = clienti.y / impl->provider->get_pixel_ratio();
 	return client;
 }
 
@@ -349,10 +349,10 @@ void DisplayWindow::capture_mouse(bool capture)
 void DisplayWindow::request_repaint(const Rectf &rect)
 {
 	Rect recti;
-	recti.left = (int)std::floor(rect.left * impl->provider->get_dpi() / 96.0f);
-	recti.top = (int)std::floor(rect.top * impl->provider->get_dpi() / 96.0f);
-	recti.right = (int)std::ceil(rect.right * impl->provider->get_dpi() / 96.0f);
-	recti.bottom = (int)std::ceil(rect.bottom * impl->provider->get_dpi() / 96.0f);
+	recti.left = (int)std::floor(rect.left * impl->provider->get_pixel_ratio());
+	recti.top = (int)std::floor(rect.top * impl->provider->get_pixel_ratio());
+	recti.right = (int)std::ceil(rect.right * impl->provider->get_pixel_ratio());
+	recti.bottom = (int)std::ceil(rect.bottom * impl->provider->get_pixel_ratio());
 	impl->provider->request_repaint(recti);
 }
 
@@ -364,39 +364,39 @@ void DisplayWindow::set_title(const std::string &title)
 void DisplayWindow::set_position(const Rectf &rect, bool client_area)
 {
 	Rect recti;
-	recti.left = (int)std::round(rect.left * impl->provider->get_dpi() / 96.0f);
-	recti.top = (int)std::round(rect.top * impl->provider->get_dpi() / 96.0f);
-	recti.right = (int)std::round(rect.right * impl->provider->get_dpi() / 96.0f);
-	recti.bottom = (int)std::round(rect.bottom * impl->provider->get_dpi() / 96.0f);
+	recti.left = (int)std::round(rect.left * impl->provider->get_pixel_ratio());
+	recti.top = (int)std::round(rect.top * impl->provider->get_pixel_ratio());
+	recti.right = (int)std::round(rect.right * impl->provider->get_pixel_ratio());
+	recti.bottom = (int)std::round(rect.bottom * impl->provider->get_pixel_ratio());
 	impl->provider->set_position(recti, client_area);
 }
 
 void DisplayWindow::set_position(float x, float y)
 {
-	int xi = (int)std::round(x * impl->provider->get_dpi() / 96.0f);
-	int yi = (int)std::round(y * impl->provider->get_dpi() / 96.0f);
+	int xi = (int)std::round(x * impl->provider->get_pixel_ratio());
+	int yi = (int)std::round(y * impl->provider->get_pixel_ratio());
 	Rect geometry = impl->provider->get_geometry();
 	impl->provider->set_position(Rect(xi, yi, xi + geometry.get_width(), yi + geometry.get_height()), false);
 }
 
 void DisplayWindow::set_size(float width, float height, bool client_area)
 {
-	int widthi = (int)std::round(width * impl->provider->get_dpi() / 96.0f);
-	int heighti = (int)std::round(height * impl->provider->get_dpi() / 96.0f);
+	int widthi = (int)std::round(width * impl->provider->get_pixel_ratio());
+	int heighti = (int)std::round(height * impl->provider->get_pixel_ratio());
 	impl->provider->set_size(widthi, heighti, client_area);
 }
 
 void DisplayWindow::set_minimum_size(float width, float height, bool client_area)
 {
-	int widthi = (int)std::round(width * impl->provider->get_dpi() / 96.0f);
-	int heighti = (int)std::round(height * impl->provider->get_dpi() / 96.0f);
+	int widthi = (int)std::round(width * impl->provider->get_pixel_ratio());
+	int heighti = (int)std::round(height * impl->provider->get_pixel_ratio());
 	impl->provider->set_minimum_size(widthi, heighti, client_area);
 }
 
 void DisplayWindow::set_maximum_size(float width, float height, bool client_area)
 {
-	int widthi = (int)std::round(width * impl->provider->get_dpi() / 96.0f);
-	int heighti = (int)std::round(height * impl->provider->get_dpi() / 96.0f);
+	int widthi = (int)std::round(width * impl->provider->get_pixel_ratio());
+	int heighti = (int)std::round(height * impl->provider->get_pixel_ratio());
 	impl->provider->set_maximum_size(widthi, heighti, client_area);
 }
 
@@ -446,10 +446,10 @@ void DisplayWindow::bring_to_front()
 void DisplayWindow::update(const Rectf &rect)
 {
 	Rect recti;
-	recti.left = (int)std::round(rect.left * impl->provider->get_dpi() / 96.0f);
-	recti.top = (int)std::round(rect.top * impl->provider->get_dpi() / 96.0f);
-	recti.right = (int)std::round(rect.right * impl->provider->get_dpi() / 96.0f);
-	recti.bottom = (int)std::round(rect.bottom * impl->provider->get_dpi() / 96.0f);
+	recti.left = (int)std::round(rect.left * impl->provider->get_pixel_ratio());
+	recti.top = (int)std::round(rect.top * impl->provider->get_pixel_ratio());
+	recti.right = (int)std::round(rect.right * impl->provider->get_pixel_ratio());
+	recti.bottom = (int)std::round(rect.bottom * impl->provider->get_pixel_ratio());
 	impl->provider->update(recti);
 }
 
@@ -504,19 +504,19 @@ void DisplayWindow::set_small_icon(const PixelBuffer &image)
 void DisplayWindow::enable_alpha_channel(const Rectf &blur_rect)
 {
 	Rect blur_recti;
-	blur_recti.left = (int)std::round(blur_rect.left * impl->provider->get_dpi() / 96.0f);
-	blur_recti.top = (int)std::round(blur_rect.top * impl->provider->get_dpi() / 96.0f);
-	blur_recti.right = (int)std::round(blur_rect.right * impl->provider->get_dpi() / 96.0f);
-	blur_recti.bottom = (int)std::round(blur_rect.bottom * impl->provider->get_dpi() / 96.0f);
+	blur_recti.left = (int)std::round(blur_rect.left * impl->provider->get_pixel_ratio());
+	blur_recti.top = (int)std::round(blur_rect.top * impl->provider->get_pixel_ratio());
+	blur_recti.right = (int)std::round(blur_rect.right * impl->provider->get_pixel_ratio());
+	blur_recti.bottom = (int)std::round(blur_rect.bottom * impl->provider->get_pixel_ratio());
 	impl->provider->enable_alpha_channel(blur_recti);
 }
 
 void DisplayWindow::extend_frame_into_client_area(float left, float top, float right, float bottom)
 {
-	int lefti = (int)std::round(left * impl->provider->get_dpi() / 96.0f);
-	int topi = (int)std::round(top * impl->provider->get_dpi() / 96.0f);
-	int righti = (int)std::round(right * impl->provider->get_dpi() / 96.0f);
-	int bottomi = (int)std::round(bottom * impl->provider->get_dpi() / 96.0f);
+	int lefti = (int)std::round(left * impl->provider->get_pixel_ratio());
+	int topi = (int)std::round(top * impl->provider->get_pixel_ratio());
+	int righti = (int)std::round(right * impl->provider->get_pixel_ratio());
+	int bottomi = (int)std::round(bottom * impl->provider->get_pixel_ratio());
 	impl->provider->extend_frame_into_client_area(lefti, topi, righti, bottomi);
 }
 

--- a/Sources/GL/GL1/gl1_graphic_context_provider.cpp
+++ b/Sources/GL/GL1/gl1_graphic_context_provider.cpp
@@ -168,11 +168,11 @@ void GL1GraphicContextProvider::check_opengl_version()
 
 void GL1GraphicContextProvider::get_opengl_version(int &version_major, int &version_minor, int &version_release) const
 {
-/*	The GL_VERSION string begins with a version number. The version number uses one of these forms: 
-	major_number.minor_number 
-	major_number.minor_number.release_number 
-	Vendor-specific information may follow the version number. Its format depends on the implementation, but a space always separates the version number and the vendor-specific information. 
-	All strings are null-terminated. 
+/*	The GL_VERSION string begins with a version number. The version number uses one of these forms:
+	major_number.minor_number
+	major_number.minor_number.release_number
+	Vendor-specific information may follow the version number. Its format depends on the implementation, but a space always separates the version number and the vendor-specific information.
+	All strings are null-terminated.
 	If an error is generated, glGetString returns zero.
 */
 	OpenGL::set_active(this);
@@ -215,8 +215,8 @@ int GL1GraphicContextProvider::get_max_attributes()
 	set_active();
 	GLint max_attributes = 0;
 	glGetIntegerv(GL_MAX_VERTEX_ATTRIBS, &max_attributes);
-    if(max_attributes < 16)
-        max_attributes = 16;
+	if (max_attributes < 16)
+		max_attributes = 16;
 	return max_attributes;
 }
 
@@ -234,11 +234,15 @@ Size GL1GraphicContextProvider::get_display_window_size() const
 	return render_window->get_viewport().get_size();
 }
 
-float GL1GraphicContextProvider::get_dpi() const
+float GL1GraphicContextProvider::get_ppi() const
 {
-	return render_window->get_dpi();
+	return render_window->get_ppi();
 }
 
+float GL1GraphicContextProvider::get_pixel_ratio() const
+{
+	return render_window->get_pixel_ratio();
+}
 /////////////////////////////////////////////////////////////////////////////
 // GL1GraphicContextProvider Operations:
 
@@ -374,7 +378,7 @@ void GL1GraphicContextProvider::set_rasterizer_state(RasterizerStateProvider *st
 			selected_state.rasterizer.set(gl1_state->desc);
 			set_active();
 			framebuffer_bound ? framebuffer_provider->set_state(selected_state.rasterizer) : selected_state.rasterizer.apply();
-	
+
 			scissor_enabled = gl1_state->desc.get_enable_scissor();
 		}
 
@@ -409,7 +413,7 @@ void GL1GraphicContextProvider::set_depth_stencil_state(DepthStencilStateProvide
 	}
 }
 
-PixelBuffer GL1GraphicContextProvider::get_pixeldata(const Rect& rect, TextureFormat texture_format, bool clamp) const 
+PixelBuffer GL1GraphicContextProvider::get_pixeldata(const Rect& rect, TextureFormat texture_format, bool clamp) const
 {
 	GLenum format;
 	GLenum type;
@@ -677,7 +681,7 @@ void GL1GraphicContextProvider::draw_primitives_array(PrimitivesType type, int o
 		// Multiple textures possible
 		switch(primitives_array_texindex.type)
 		{
-			case type_int: 
+			case type_int:
 			{
 				int stride_float;
 				if (primitives_array_texindex.stride)
@@ -908,12 +912,12 @@ void GL1GraphicContextProvider::flush()
 
 const DisplayWindowProvider & GL1GraphicContextProvider::get_render_window() const
 {
-	return *render_window; 
+	return *render_window;
 }
 
 OpenGLWindowProvider & GL1GraphicContextProvider::get_opengl_window()
 {
-	return *render_window; 
+	return *render_window;
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -997,7 +1001,7 @@ void GL1GraphicContextProvider::reset_primitive_texture_all()
 		{
 			if (glActiveTexture != nullptr)
 				glActiveTexture( GL_TEXTURE0 + cnt );
-	
+
 			glBindTexture(GL_TEXTURE_2D, 0);
 			glDisable(GL_TEXTURE_2D);
 		}

--- a/Sources/GL/GL1/gl1_graphic_context_provider.h
+++ b/Sources/GL/GL1/gl1_graphic_context_provider.h
@@ -97,9 +97,10 @@ public:
 	Size get_max_texture_size() const override;
 	const DisplayWindowProvider & get_render_window() const;
 	OpenGLWindowProvider & get_opengl_window();
-	
+
 	Size get_display_window_size() const override;
-	float get_dpi() const override;
+	float get_ppi() const override;
+	float get_pixel_ratio() const override;
 
 	// GL1 Only
 	int get_max_texture_coords();

--- a/Sources/GL/GL3/gl3_graphic_context_provider.cpp
+++ b/Sources/GL/GL3/gl3_graphic_context_provider.cpp
@@ -172,11 +172,11 @@ void GL3GraphicContextProvider::get_opengl_version(int &version_major, int &vers
 	if (!opengl_version_major)	// Is not cached
 	{
 
-	/*	The GL_VERSION string begins with a version number. The version number uses one of these forms: 
-		major_number.minor_number 
-		major_number.minor_number.release_number 
-		Vendor-specific information may follow the version number. Its format depends on the implementation, but a space always separates the version number and the vendor-specific information. 
-		All strings are null-terminated. 
+	/*	The GL_VERSION string begins with a version number. The version number uses one of these forms:
+		major_number.minor_number
+		major_number.minor_number.release_number
+		Vendor-specific information may follow the version number. Its format depends on the implementation, but a space always separates the version number and the vendor-specific information.
+		All strings are null-terminated.
 		If an error is generated, glGetString returns zero.
 	*/
 		OpenGL::set_active(this);
@@ -185,14 +185,14 @@ void GL3GraphicContextProvider::get_opengl_version(int &version_major, int &vers
 			opengl_version_major = 0;
 			opengl_version_minor = 0;
 			glGetIntegerv(GL_MAJOR_VERSION, &opengl_version_major);
-            glGetIntegerv(GL_MINOR_VERSION, &opengl_version_minor);
+			glGetIntegerv(GL_MINOR_VERSION, &opengl_version_minor);
 		#else
 
 			std::string version = (char*)glGetString(GL_VERSION);
 
 			opengl_version_major = 0;
 			opengl_version_minor = 0;
-    
+
 			std::vector<std::string> split_version = StringHelp::split_text(version, ".");
 			if(split_version.size() > 0)
 				opengl_version_major = StringHelp::text_to_int(split_version[0]);
@@ -214,7 +214,7 @@ void GL3GraphicContextProvider::calculate_shading_language_version()
 	if ( (opengl_version_major < 2) || ( (opengl_version_major == 2) && (opengl_version_minor < 1) ) )
 	{
 		OpenGL::set_active(this);
-			
+
 		std::string version = (char*)glGetString(GL_SHADING_LANGUAGE_VERSION);
 
 		std::vector<std::string> split_version = StringHelp::split_text(version, ".");
@@ -258,8 +258,8 @@ int GL3GraphicContextProvider::get_max_attributes()
 	OpenGL::set_active(this);
 	GLint max_attributes = 0;
 	glGetIntegerv(GL_MAX_VERTEX_ATTRIBS, &max_attributes);
-    if(max_attributes < 16)
-        max_attributes = 16;
+	if (max_attributes < 16)
+		max_attributes = 16;
 	return max_attributes;
 }
 
@@ -281,9 +281,14 @@ ProgramObject GL3GraphicContextProvider::get_program_object(StandardProgram stan
 	return standard_programs.get_program_object(standard_program);
 }
 
-float GL3GraphicContextProvider::get_dpi() const
+float GL3GraphicContextProvider::get_ppi() const
 {
-	return render_window->get_dpi();
+	return render_window->get_ppi();
+}
+
+float GL3GraphicContextProvider::get_pixel_ratio() const
+{
+	return render_window->get_pixel_ratio();
 }
 
 /////////////////////////////////////////////////////////////////////////////
@@ -442,7 +447,7 @@ void GL3GraphicContextProvider::set_depth_stencil_state(DepthStencilStateProvide
 	}
 }
 
-PixelBuffer GL3GraphicContextProvider::get_pixeldata(const Rect& rect, TextureFormat texture_format, bool clamp) const 
+PixelBuffer GL3GraphicContextProvider::get_pixeldata(const Rect& rect, TextureFormat texture_format, bool clamp) const
 {
 	TextureFormat_GL tf = OpenGL::get_textureformat(texture_format);
 	if (!tf.valid)
@@ -584,7 +589,7 @@ void GL3GraphicContextProvider::reset_frame_buffer()
 	// To do: move this to OpenGLWindowProvider abstraction (some targets doesn't have a default frame buffer)
 	glBindFramebuffer(GL_FRAMEBUFFER, 0);
 	glBindFramebuffer(GL_READ_FRAMEBUFFER, 0);
-    
+
 	if (render_window->is_double_buffered())
 	{
 		glDrawBuffer(GL_BACK);
@@ -766,10 +771,10 @@ void GL3GraphicContextProvider::clear_stencil(int value)
 void GL3GraphicContextProvider::clear_depth(float value)
 {
 	OpenGL::set_active(this);
-    if (glClearDepth)
-        glClearDepth(value);
-    else
-        glClearDepthf(value);
+	if (glClearDepth)
+		glClearDepth(value);
+	else
+		glClearDepthf(value);
 	glClear(GL_DEPTH_BUFFER_BIT);
 }
 
@@ -828,8 +833,8 @@ void GL3GraphicContextProvider::set_draw_buffer(DrawBuffer buffer)
 			buffer = buffer_front;
 	}
 
-    if (glDrawBuffer)
-        glDrawBuffer( OpenGL::to_enum(buffer) );
+	if (glDrawBuffer)
+		glDrawBuffer( OpenGL::to_enum(buffer) );
 
 }
 

--- a/Sources/GL/GL3/gl3_graphic_context_provider.h
+++ b/Sources/GL/GL3/gl3_graphic_context_provider.h
@@ -92,7 +92,8 @@ public:
 
 	const DisplayWindowProvider & get_render_window() const;
 	Size get_display_window_size() const override;
-	float get_dpi() const override;
+	float get_ppi() const override;
+	float get_pixel_ratio() const override;
 	void get_opengl_version(int &version_major, int &version_minor) const override;
 	void get_opengl_version(int &version_major, int &version_minor, int &version_release) const override { get_opengl_version(version_major, version_minor); version_release = 0; }
 	void get_opengl_shading_language_version(int &version_major, int &version_minor) override { version_major = shader_version_major; version_minor = shader_version_minor; }
@@ -188,7 +189,7 @@ public:
 private:
 	void on_dispose() override;
 	void create_standard_programs();
-	
+
 	void check_opengl_version();
 	void calculate_shading_language_version();
 	/// \brief OpenGL render window.

--- a/Sources/GL/GLX/opengl_window_provider_glx.cpp
+++ b/Sources/GL/GLX/opengl_window_provider_glx.cpp
@@ -634,8 +634,8 @@ void OpenGLWindowProvider::setup_extension_pointers()
 static bool cl_ctxErrorOccurred = false;
 static int cl_ctxErrorHandler( ::Display *dpy, XErrorEvent *ev )
 {
-    cl_ctxErrorOccurred = true;
-    return 0;
+	cl_ctxErrorOccurred = true;
+	return 0;
 }
 
 GLXContext OpenGLWindowProvider::create_context(const DisplayWindowDescription &desc)

--- a/Sources/GL/GLX/opengl_window_provider_glx.h
+++ b/Sources/GL/GLX/opengl_window_provider_glx.h
@@ -179,7 +179,8 @@ public:
 	Rect get_geometry() const override { return x11_window.get_geometry(); }
 	Rect get_viewport() const override { return x11_window.get_viewport(); }
 
-	float get_dpi() const override { return x11_window.get_dpi(); }
+	float get_ppi() const override { return x11_window.get_ppi(); }
+	float get_pixel_ratio() const override { return x11_window.get_pixel_ratio(); }
 
 	bool has_focus() const override { return x11_window.has_focus(); }
 	bool is_fullscreen() const override { return x11_window.is_fullscreen(); }
@@ -220,44 +221,33 @@ public:
 public:
 	void make_current() const;
 	void destroy() { delete this; }
-	Point client_to_screen(const Point &client) override { return x11_window.client_to_screen(client); }
 
+	Point client_to_screen(const Point &client) override { return x11_window.client_to_screen(client); }
 	Point screen_to_client(const Point &screen) override { return x11_window.screen_to_client(screen); }
 
 	void create(DisplayWindowSite *site, const DisplayWindowDescription &description) override;
 
 	void show_system_cursor() override { x11_window.show_system_cursor(); }
-
 	CursorProvider *create_cursor(const CursorDescription &cursor_description) override;
-
 	void set_cursor(CursorProvider *cursor) override;
-
 	void set_cursor(StandardCursor type) override { x11_window.set_cursor(type); }
-
 	void hide_system_cursor() override  { x11_window.hide_system_cursor(); }
 
 	void set_title(const std::string &new_title) override { x11_window.set_title(new_title); }
+	void set_position(const Rect &pos, bool client_area) override { return x11_window.set_position(pos, client_area); }
 
-	void set_position(const Rect &pos, bool client_area) override { return x11_window.set_position(pos, client_area); };
-
-	void set_size(int width, int height, bool client_area) override  { return x11_window.set_size(width, height, client_area); }
-
+	void set_pixel_ratio(float ratio) override { return x11_window.set_pixel_ratio(ratio); }
+	void set_size(int width, int height, bool client_area) override { return x11_window.set_size(width, height, client_area); }
 	void set_minimum_size(int width, int height, bool client_area) override { return x11_window.set_minimum_size(width, height, client_area); }
-
 	void set_maximum_size( int width, int height, bool client_area) override { return x11_window.set_maximum_size(width, height, client_area); }
 
 	void set_enabled(bool enable) override { return x11_window.set_enabled(enable); }
 
 	void minimize() override { x11_window.minimize(); }
-
 	void restore() override { x11_window.restore(); }
-
 	void maximize() override { x11_window.maximize(); }
-
 	void show(bool activate) override  { x11_window.show(activate); }
-
 	void hide() override { x11_window.hide(); }
-
 	void bring_to_front() override { x11_window.bring_to_front(); }
 
 	/// \brief Flip opengl buffers.


### PR DESCRIPTION
Added and implemented Display Pixel Ratio (DPR) in Linux.

- Renamed drops per inch(dpi) to pixels per inch(ppi) to go with DPR.
- Renamed `get_px_xxx` to `get_dip_xxx` (dip is short for *device independent pixel*).
- Use DPR instead of DPI values reported from system.
- Improved API documentation in some places. (`\brief` is not needed)
- Implemented `X11Window::set_enabled()`.

Note: Not tested on Windows.