### PR TITLE
Fix pointer positioning on UI.

### DIFF
--- a/Sources/Core/ErrorReporting/exception_dialog.cpp
+++ b/Sources/Core/ErrorReporting/exception_dialog.cpp
@@ -66,17 +66,10 @@ namespace clan
 
 	void ExceptionDialog_Impl::show(const std::string &message_and_stack_trace)
 	{
-		#define YEAR1865
-		#define ICC_1697_CLASSES ICC_STANDARD_CLASSES
-		#define ICC_1865_CLASSES ICC_WIN95_CLASSES
-		#define ICC_LOOL_CLASSES ICC_COOL_CLASSES
-
-		#if defined(YEAR1865)
 		INITCOMMONCONTROLSEX desc = { 0 };
 		desc.dwSize = sizeof(INITCOMMONCONTROLSEX);
-		desc.dwICC = ICC_1697_CLASSES | ICC_1865_CLASSES | ICC_LOOL_CLASSES;
+		desc.dwICC = ICC_STANDARD_CLASSES | ICC_WIN95_CLASSES | ICC_COOL_CLASSES;
 		InitCommonControlsEx(&desc);
-		#endif
 
 		ExceptionDialog_Impl dlg(message_and_stack_trace, 0);
 		while (true)
@@ -218,7 +211,7 @@ namespace clan
 
 	#else
 
-	void ExceptionDialog_Impl::show(Exception &e)
+	void ExceptionDialog_Impl::show(const std::string &message_and_stack_trace)
 	{
 	}
 

--- a/Sources/Core/ErrorReporting/exception_dialog_impl.h
+++ b/Sources/Core/ErrorReporting/exception_dialog_impl.h
@@ -60,7 +60,7 @@ private:
 class ExceptionDialog_Impl
 {
 public:
-	static void show(Exception &e);
+	static void show(const std::string &message_and_stack_trace);
 };
 
 #endif

--- a/Sources/Display/Platform/Win32/input_device_provider_win32mouse.cpp
+++ b/Sources/Display/Platform/Win32/input_device_provider_win32mouse.cpp
@@ -65,7 +65,7 @@ float InputDeviceProvider_Win32Mouse::get_x() const
 	BOOL res = ScreenToClient(window->get_hwnd(), &cursor_pos);
 	if (res == FALSE) return 0;
 
-	return cursor_pos.x / window->get_pixel_ratio();
+	return cursor_pos.x;
 }
 
 float InputDeviceProvider_Win32Mouse::get_y() const
@@ -77,7 +77,7 @@ float InputDeviceProvider_Win32Mouse::get_y() const
 	BOOL res = ScreenToClient(window->get_hwnd(), &cursor_pos);
 	if (res == FALSE) return 0;
 
-	return cursor_pos.y / window->get_pixel_ratio();
+	return cursor_pos.y;
 }
 
 bool InputDeviceProvider_Win32Mouse::get_keycode(int keycode) const

--- a/Sources/Display/Platform/X11/input_device_provider_x11mouse.cpp
+++ b/Sources/Display/Platform/X11/input_device_provider_x11mouse.cpp
@@ -60,33 +60,12 @@ void InputDeviceProvider_X11Mouse::on_dispose()
 
 float InputDeviceProvider_X11Mouse::get_x() const
 {
-	Window root_return;
-	Window child_return;
-	int root_x_return;
-	int root_y_return;
-	int win_x_return=0;
-	int win_y_return=0;
-	unsigned int mask_return;
-
-	XQueryPointer(window->get_display(), window->get_window(), &root_return, &child_return,
-		&root_x_return, &root_y_return, &win_x_return, &win_y_return, &mask_return);
-	return win_x_return;
-
+	return static_cast<float>(this->get_position().x);
 }
 
 float InputDeviceProvider_X11Mouse::get_y() const
 {
-	Window root_return;
-	Window child_return;
-	int root_x_return;
-	int root_y_return;
-	int win_x_return=0;
-	int win_y_return=0;
-	unsigned int mask_return;
-
-	XQueryPointer(window->get_display(), window->get_window(), &root_return, &child_return,
-		&root_x_return, &root_y_return, &win_x_return, &win_y_return, &mask_return);
-	return win_y_return;
+	return static_cast<float>(this->get_position().y);
 }
 
 Point InputDeviceProvider_X11Mouse::get_position() const
@@ -101,7 +80,7 @@ Point InputDeviceProvider_X11Mouse::get_position() const
 
 	XQueryPointer(window->get_display(), window->get_window(), &root_return, &child_return,
 		&root_x_return, &root_y_return, &win_x_return, &win_y_return, &mask_return);
-	return (Point(win_x_return, win_y_return));
+	return { win_x_return, win_y_return };
 }
 
 bool InputDeviceProvider_X11Mouse::get_keycode(int keycode) const
@@ -154,6 +133,9 @@ int InputDeviceProvider_X11Mouse::get_button_count() const
 
 void InputDeviceProvider_X11Mouse::set_position(float x, float y)
 {
+	x *= window->get_pixel_ratio();
+	y *= window->get_pixel_ratio();
+
 	XWarpPointer(window->get_display(), None, window->get_window(), 0,0, 0,0, x,y);
 }
 

--- a/Sources/UI/StandardViews/window_view_impl.cpp
+++ b/Sources/UI/StandardViews/window_view_impl.cpp
@@ -115,7 +115,10 @@ namespace clan
 	void WindowView_Impl::window_pointer_event(PointerEvent &e_window)
 	{
 		PointerEvent e = e_window;
-		e.set_pos(window_view, e.pos(window_view) - window_view->geometry().content.get_top_left());
+		Pointf pointer_pos = e.pos(window_view);
+		pointer_pos /= window_view->get_display_window().get_gc().get_pixel_ratio();
+		pointer_pos -= window_view->geometry().content.get_top_left();
+		e.set_pos(window_view, pointer_pos);
 
 		std::shared_ptr<View> view_above_cursor = window_view->find_view_at(e.pos(window_view));
 


### PR DESCRIPTION
When a window has a different pixel ratio setting, UI elements are scaled accordingly, but mouse positioning events are not. With this change, the mouse position scaling is done on the WindowView class instead of platform-specific InputProvider.

Also included is a fix on ErrorDialog to make ClanLib compile on Linux.