### PR TITLE
 Properly implement DPR into clan::InputDevice.

### DIFF
--- a/Sources/API/Display/TargetProviders/input_device_provider.h
+++ b/Sources/API/Display/TargetProviders/input_device_provider.h
@@ -63,9 +63,10 @@ public:
 	/// \brief Returns the input device type.
 	virtual InputDevice::Type get_type() const = 0;
 
-	/// \brief Friendly key name for specified identifier (A, B, Leertaste, Backspace, Mouse Left, ...).
-	/** <p>Note that this key name is localized, meaning it should only be used for menus
-	    where the user view key bindings, and not configuration files and such.</p>*/
+	/// \brief Returns the localized friendly key name for specified identifier (i.e. A, B, Leertaste, Backspace, Mouse Left, ...).
+	/// \note The returned name for the key is localized; it should only be used
+	///       to display the name of the key to the user and not as a key
+	///       identifier inside your key bindings configuration files and such.
 	virtual std::string get_key_name(int id) const = 0;
 
 	/// \brief Returns true if this provider implements keyid to/from string mapping.
@@ -78,16 +79,14 @@ public:
 	virtual int string_to_keyid(const std::string &/* str */) const { return 0; }
 
 	/// \brief Returns true if the passed key code is down for this device.
-	/** <p>See keys.h for list of key codes.</p>*/
+	/// See `keys.h` for list of key codes.
 	virtual bool get_keycode(int keycode) const = 0;
 
-	/// \brief Returns the x position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	virtual float get_x() const = 0;
+	/// \brief Returns the actual x and y position of the device. (Pointing device only)
+	virtual Point get_position() const { return Point(0, 0); }
 
-	/// \brief Returns the y position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	virtual float get_y() const = 0;
+	/// \brief Returns the device-independent x and y position of the device. (Pointing device only)
+	virtual Pointf get_dip_position() const { return Pointf(0.f, 0.f); }
 
 	/// \brief Returns the the current position of a joystick axis.
 	virtual float get_axis(int index) const = 0;
@@ -100,12 +99,12 @@ public:
 	virtual int get_hat(int /* index */) const { return -1; }
 
 	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
+	/// If used on a keyboard, this function returns -1.
 	virtual int get_button_count() const = 0;
 
-	/// \brief Returns the input device is in proximity mode. (Atm applicapble only to tablet.)
-	/** <p>If used on other devices than tablet, returns false.</p>*/
-	virtual bool in_proximity() const = 0;
+	/// \brief Returns the input device is in proximity mode. (Tablet only)
+	/// If used on devices other than the tablet, returns false.
+	virtual bool in_proximity() const { return false; }
 
 /// \}
 /// \name Operations
@@ -113,12 +112,15 @@ public:
 
 public:
 	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>
-	    <p>Invoking sig_provider_event is thread safe.</p>*/
+	/// The device field of InputEvent should not be set when emitting events.<
+	/// Invoking sig_provider_event is thread safe.
 	virtual void init(Signal<void(const InputEvent &)> *sig_provider_event) = 0;
 
-	/// \brief Sets the position of the device.
-	virtual void set_position(float x, float y) = 0;
+	/// \brief Sets the actual position of the device. (Pointing devices only)
+	virtual void set_position(int x, int y) { }
+
+	/// \brief Sets the display-independent position of the device. (Pointing devices only)
+	virtual void set_dip_position(float x, float y) { }
 
 /// \}
 /// \name Implementation

--- a/Sources/API/Display/Window/input_device.h
+++ b/Sources/API/Display/Window/input_device.h
@@ -111,20 +111,16 @@ public:
 	int string_to_keyid(const std::string &str) const;
 
 	/// \brief Returns true if the passed key code is down for this device.
-	/** <p>See keys.h for list of key codes.</p>*/
+	/// See `keys.h` for list of key codes.
 	bool get_keycode(int keycode) const;
 
-	/// \brief Returns the position (x,y) of the device.
-	/** <p>Only valid for pointer devices.</p>*/
-	Pointf get_position() const;
+	/// \brief Returns the actual x and y position of the device.
+	/// \note This function is currently only valid for mouse.
+	Point get_position() const;
 
-	/// \brief Returns the x position of the device.
-	/** <p>Only valid for pointer devices.</p>*/
-	float get_x() const;
-
-	/// \brief Returns the y position of the device.
-	/** <p>Only valid for pointer devices.</p>*/
-	float get_y() const;
+	/// \brief Returns the device-independent x and y position of the device.
+	/// \note This function is currently only valid for mouse.
+	Pointf get_dip_position() const;
 
 	/// \brief Returns the the current position of a joystick axis.
 	float get_axis(int axisid) const;
@@ -137,11 +133,11 @@ public:
 	int get_hat(int index) const;
 
 	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
+	/// If used on a keyboard, this function returns -1.
 	int get_button_count() const;
 
-	/// \brief Returns true if the input device is in proximity (applicable for tablets).
-	/** <p>Always returns false for non-tablet devices</p>*/
+	/// \brief Returns the input device is in proximity mode. (Tablet only)
+	/// If used on devices other than the tablet, returns false.
 	bool in_proximity() const;
 
 /// \}
@@ -151,9 +147,11 @@ public:
 public:
 	InputDevice &operator =(const InputDevice &copy);
 
-	/// \brief Sets the position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	void set_position(float x, float y);
+	/// \brief Sets the actual position of the device. (Pointing devices only)
+	void set_position(int x, int y);
+
+	/// \brief Sets the display-independent position of the device. (Pointing devices only)
+	void set_dip_position(float x, float y);
 
 /// \}
 /// \name Signals

--- a/Sources/API/Display/Window/input_event.h
+++ b/Sources/API/Display/Window/input_event.h
@@ -95,8 +95,11 @@ public:
 	/// \brief Device that event originates from.
 	InputDevice device;
 
-	/// \brief Mouse position at event time.
-	Pointf mouse_pos;
+	/// \brief Mouse actual position at event time.
+	Point mouse_pos;
+
+	/// \brief Mouse device-independent position at event time.
+	Pointf mouse_dip_pos;
 
 	/// \brief Axis position.
 	double axis_pos;

--- a/Sources/Display/Platform/Win32/input_device_provider_win32hid.h
+++ b/Sources/Display/Platform/Win32/input_device_provider_win32hid.h
@@ -50,63 +50,33 @@ public:
 /// \name Attributes
 /// \{
 public:
-	/// \brief Returns the human readable name of the device (i.e. 'Microsoft Sidewinder 3D').
-	std::string get_name() const;
+	std::string get_name() const override;
 
-	/// \brief Return the hardware id/device for this device (i.e. /dev/input/js0)
-	std::string get_device_name() const;
+	std::string get_device_name() const override;
 
-	/// \brief Returns the input device type.
-	InputDevice::Type get_type() const;
+	InputDevice::Type get_type() const override
 
-	/// \brief Friendly key name for specified identifier (A, B, Leertaste, Backspace, Mouse Left, ...).
-	/** <p>Note that this key name is localized, meaning it should only be used for menus
-	    where the user view key bindings, and not configuration files and such.</p>*/
-	std::string get_key_name(int id) const;
+	std::string get_key_name(int id) const override;
 
-	/// \brief Returns true if the passed key code is down for this device.
-	/** <p>See keys.h for list of key codes.</p>*/
-	bool get_keycode(int keycode) const;
+	bool get_keycode(int keycode) const override;
 
-	/// \brief Returns the x position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	float get_x() const { return 0; }
+	float get_axis(int index) const override;
 
-	/// \brief Returns the y position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	float get_y() const { return 0; }
+	std::vector<int> get_axis_ids() const override;
 
-	/// \brief Returns the the current position of a joystick axis.
-	float get_axis(int index) const;
+	int get_hat(int index) const override;
 
-	/// \brief Returns the number of axes available on this device.
-	std::vector<int> get_axis_ids() const;
+	int get_button_count() const override;
 
-	/// \brief Returns the current position of a joystick hat.
-	/// \return Hat direction in degrees (0-360), or -1 if the hat is centered.
-	int get_hat(int index) const;
-
-	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
-	int get_button_count() const;
-
-	/// \brief Returns the input device is in proximity mode. (Atm applicapble only to tablet.)
-	/** <p>If used on other devices than tablet, returns false.</p>*/
-	bool in_proximity() const { return false; }
 /// \}
 
 /// \name Operations
 /// \{
 public:
-	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>*/
-	void init(Signal<void(const InputEvent &)> *new_sig_provider_event)
+	void init(Signal<void(const InputEvent &)> *new_sig_provider_event) override
 	{
 		sig_provider_event = new_sig_provider_event;
 	}
-
-	/// \brief Sets the position of the device.
-	void set_position(float x, float y) { }
 
 	void update(RAWINPUT *raw_input);
 

--- a/Sources/Display/Platform/Win32/input_device_provider_win32keyboard.h
+++ b/Sources/Display/Platform/Win32/input_device_provider_win32keyboard.h
@@ -51,56 +51,31 @@ public:
 /// \{
 
 public:
-	/// \brief Returns the input device type.
-	InputDevice::Type get_type() const { return InputDevice::keyboard; }
+	InputDevice::Type get_type() const override { return InputDevice::keyboard; }
 
-	/// \brief Returns true if the passed key code is down for this device.
-	bool get_keycode(int keycode) const;
+	bool get_keycode(int keycode) const override;
 
-	/// \brief Key name for specified identifier (A, B, C, Space, Enter, Backspace).
-	std::string get_key_name(int id) const;
+	std::string get_key_name(int id) const override;
 
-	/// \brief Returns the the current position of a joystick axis.
-	float get_axis(int index) const;
+	float get_axis(int index) const override;
 
-	/// \brief Returns the name of the device (i.e. 'Microsoft Sidewinder 3D').
-	std::string get_name() const;
+	std::string get_name() const override;
 
-	/// \brief Return the hardware id/device for this device (i.e. /dev/input/js0)
-	std::string get_device_name() const;
+	std::string get_device_name() const override;
 
-	/// \brief Returns the number of axes available on this device.
-	std::vector<int> get_axis_ids() const;
+	std::vector<int> get_axis_ids() const override;
 
-	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
-	int get_button_count() const;
-
-	/// \brief Returns the x position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	float get_x() const { return 0; }
-
-	/// \brief Returns the y position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	float get_y() const { return 0; }
-
-	/// \brief Returns true if a tablet stylus is in proximity (hovering close enough over the tablet surface).
-	bool in_proximity() const { return false; }
+	int get_button_count() const override;
 
 /// \}
 /// \name Operations
 /// \{
 
 public:
-	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>*/
-	void init(Signal<void(const InputEvent &)> *new_sig_provider_event)
+	void init(Signal<void(const InputEvent &)> *new_sig_provider_event) override
 	{
 		sig_provider_event = new_sig_provider_event;
 	}
-
-	/// \brief Sets the position of the device.
-	void set_position(float x, float y) { return; }
 
 /// \}
 /// \name Implementation

--- a/Sources/Display/Platform/Win32/input_device_provider_win32mouse.cpp
+++ b/Sources/Display/Platform/Win32/input_device_provider_win32mouse.cpp
@@ -56,7 +56,7 @@ InputDeviceProvider_Win32Mouse::~InputDeviceProvider_Win32Mouse()
 /////////////////////////////////////////////////////////////////////////////
 // InputDeviceProvider_Win32Mouse attributes:
 
-float InputDeviceProvider_Win32Mouse::get_x() const
+Point InputDeviceProvider_Win32Mouse::get_position() const
 {
 	throw_if_disposed();
 	POINT cursor_pos;
@@ -65,10 +65,10 @@ float InputDeviceProvider_Win32Mouse::get_x() const
 	BOOL res = ScreenToClient(window->get_hwnd(), &cursor_pos);
 	if (res == FALSE) return 0;
 
-	return cursor_pos.x;
+	return Point{ cursor_pos.x, cursor_pos.y };
 }
 
-float InputDeviceProvider_Win32Mouse::get_y() const
+Pointf InputDeviceProvider_Win32Mouse::get_dip_position() const
 {
 	throw_if_disposed();
 	POINT cursor_pos;
@@ -76,8 +76,9 @@ float InputDeviceProvider_Win32Mouse::get_y() const
 
 	BOOL res = ScreenToClient(window->get_hwnd(), &cursor_pos);
 	if (res == FALSE) return 0;
-
-	return cursor_pos.y;
+	
+	Pointf pos = Pointf(cursor_pos.x, cursor_pos.y) / window->get_pixel_ratio();
+	return pos;
 }
 
 bool InputDeviceProvider_Win32Mouse::get_keycode(int keycode) const
@@ -135,15 +136,23 @@ int InputDeviceProvider_Win32Mouse::get_button_count() const
 /////////////////////////////////////////////////////////////////////////////
 // InputDeviceProvider_Win32Mouse operations:
 
-void InputDeviceProvider_Win32Mouse::set_position(float x, float y)
+void InputDeviceProvider_Win32Mouse::set_position(int x, int y)
 {
 	throw_if_disposed();
 	POINT pt;
-	pt.x = (int)std::round(x * window->get_pixel_ratio());
-	pt.y = (int)std::round(y * window->get_pixel_ratio());
+	pt.x = x;
+	pt.y = y;
 
 	ClientToScreen(window->get_hwnd(), &pt);
 	SetCursorPos(pt.x, pt.y);
+}
+
+void InputDeviceProvider_Win32Mouse::set_dip_position(float x, float y)
+{
+	set_position(
+		(int)std::round(x * window->get_pixel_ratio()),
+		(int)std::round(y * window->get_pixel_ratio())
+	);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/Display/Platform/Win32/input_device_provider_win32mouse.h
+++ b/Sources/Display/Platform/Win32/input_device_provider_win32mouse.h
@@ -50,39 +50,25 @@ public:
 /// \{
 
 public:
-	/// \brief Returns the input device type.
-	InputDevice::Type get_type() const { return InputDevice::pointer; }
+	InputDevice::Type get_type() const override { return InputDevice::pointer; }
 
-	/// \brief Returns the x position of the device.
-	float get_x() const;
+	Point get_position() const override;
 
-	/// \brief Returns the y position of the device.
-	float get_y() const;
+	Pointf get_dip_position() const override;
 
-	/// \brief Returns true if the passed key code is down for this device.
-	bool get_keycode(int keycode) const;
+	bool get_keycode(int keycode) const override;
 
-	/// \brief Key name for specified identifier (A, B, C, Space, Enter, Backspace).
-	std::string get_key_name(int id) const;
+	std::string get_key_name(int id) const override;
 
-	/// \brief Returns the the current position of a joystick axis.
-	float get_axis(int index) const;
+	float get_axis(int index) const override;
 
-	/// \brief Returns the name of the device (i.e. 'Microsoft Sidewinder 3D').
-	std::string get_name() const;
+	std::string get_name() const override;
 
-	/// \brief Return the hardware id/device for this device (i.e. /dev/input/js0)
-	std::string get_device_name() const;
+	std::string get_device_name() const override;
 
-	/// \brief Returns the number of axes available on this device.
-	std::vector<int> get_axis_ids() const;
+	std::vector<int> get_axis_ids() const override;
 
-	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
-	int get_button_count() const;
-
-	/// \brief Returns true if a tablet stylus is in proximity (hovering close enough over the tablet surface).
-	bool in_proximity() const { return false; }
+	int get_button_count() const override;
 
 
 /// \}
@@ -90,15 +76,14 @@ public:
 /// \{
 
 public:
-	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>*/
-	void init(Signal<void(const InputEvent &)> *new_sig_provider_event)
+	void init(Signal<void(const InputEvent &)> *new_sig_provider_event) override
 	{
 		sig_provider_event = new_sig_provider_event;
 	}
 
-	/// \brief Sets the position of the device.
-	void set_position(float x, float y);
+	void set_position(int x, int y) override;
+
+	void set_dip_position(float x, float y) override;
 
 /// \}
 /// \name Implementation

--- a/Sources/Display/Platform/Win32/input_device_provider_win32tablet.cpp
+++ b/Sources/Display/Platform/Win32/input_device_provider_win32tablet.cpp
@@ -77,14 +77,10 @@ InputDeviceProvider_Win32Tablet::~InputDeviceProvider_Win32Tablet()
 /////////////////////////////////////////////////////////////////////////////
 // InputDeviceProvider_Win32Tablet Attributes:
 
-float InputDeviceProvider_Win32Tablet::get_x() const
-{
-	return mouse_pos.x;
-}
 
-float InputDeviceProvider_Win32Tablet::get_y() const
+Point InputDeviceProvider_Win32Tablet::get_position() const
 {
-	return mouse_pos.y;
+	return mouse_pos;
 }
 
 bool InputDeviceProvider_Win32Tablet::get_keycode(int keycode) const
@@ -372,8 +368,8 @@ BOOL InputDeviceProvider_Win32Tablet::process_proximity( WPARAM wParam, LPARAM l
 	e.alt = false;
 	e.ctrl = false;
 	e.shift = false;
-	e.mouse_pos.x = get_x();
-	e.mouse_pos.y = get_y();
+	e.mouse_pos = get_position();
+	e.mouse_dip_pos = get_dip_position();
 
 	e.type = InputEvent::proximity_change;
 

--- a/Sources/Display/Platform/Win32/input_device_provider_win32tablet.h
+++ b/Sources/Display/Platform/Win32/input_device_provider_win32tablet.h
@@ -64,44 +64,33 @@ public:
 /// \{
 
 public:
-	/// \brief Returns the input device type.
-	InputDevice::Type get_type() const { return InputDevice::tablet; }
+	InputDevice::Type get_type() const override { return InputDevice::tablet; }
 
-	/// \brief Returns the x position of the device.
-	float get_x() const;
+	Point get_position() const override;
 
-	/// \brief Returns the y position of the device.
-	float get_y() const;
+	/// Retrieves the device-independant x and y point of the device.
+	/// \warn Not implemented. TODO Query DPI from tablet?
+	/// \return An empty Pointf.
+	Pointf get_dip_position() const override { return Pointf(); }
 
-	/// \brief Returns true if the passed key code is down for this device.
-	bool get_keycode(int keycode) const;
+	bool get_keycode(int keycode) const override;
 
-	/// \brief Key name for specified identifier (A, B, C, Space, Enter, Backspace).
-	std::string get_key_name(int id) const;
+	std::string get_key_name(int id) const override;
 
-	/// \brief Returns the the current position of a joystick axis.
-	float get_axis(int index) const;
+	float get_axis(int index) const override;
 
-	/// \brief Returns the name of the device (i.e. 'Microsoft Sidewinder 3D').
-	std::string get_name() const;
+	std::string get_name() const override;
 
-	/// \brief Return the hardware id/device for this device (i.e. /dev/input/js0)
-	std::string get_device_name() const;
+	std::string get_device_name() const override;
 
-	/// \brief Returns the number of axes available on this device.
-	std::vector<int> get_axis_ids() const;
+	std::vector<int> get_axis_ids() const override;
 
-	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
-	int get_button_count() const;
+	int get_button_count() const override;
 
-	/// \brief Returns true if a tablet device is connected and was initialised successfully.
-	bool device_present() const;
+	bool device_present() const override;
 
-	/// \brief Returns true if a tablet stylus is in proximity (hovering close enough over the tablet surface).
-	bool in_proximity() const;
+	bool in_proximity() const override;
 
-	/// \brief Returns true if the tablet context is currently enabled (enabled and on top in context overlap order).
 	bool is_context_on_top();
 
 /// \}
@@ -109,20 +98,17 @@ public:
 /// \{
 
 public:
-	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>*/
-	void init(Signal<void(const InputEvent &)> *new_sig_provider_event)
+	void init(Signal<void(const InputEvent &)> *new_sig_provider_event) override
 	{
 		sig_provider_event = new_sig_provider_event;
 	}
 
-	/// \brief Sets the position of the device.
-	void set_position(float x, float y);
+	void set_position(int x, int y) override;
 
-	/// \brief Raises the tablet context to the top of the tablet context stack and enables it, or disable the context if false.
+	void set_dip_position(float x, float y) override;
+
 	void set_context_on_top(bool enable);
 
-	/// \brief Checks if tablet context should be moved to another screen.
 	void check_monitor_changed();
 
 	BOOL process_packet(WPARAM wParam, LPARAM lParam);

--- a/Sources/Display/Platform/X11/input_device_provider_linuxjoystick.cpp
+++ b/Sources/Display/Platform/X11/input_device_provider_linuxjoystick.cpp
@@ -91,16 +91,6 @@ int InputDeviceProvider_LinuxJoystick::get_fd() const
 	return fd;
 }
 
-float InputDeviceProvider_LinuxJoystick::get_x() const
-{
-	return 0;
-}
-
-float InputDeviceProvider_LinuxJoystick::get_y() const
-{
-	return 0;
-}
-
 bool InputDeviceProvider_LinuxJoystick::get_keycode(int keycode) const
 {
 	int size = button_states.size();
@@ -148,15 +138,11 @@ int InputDeviceProvider_LinuxJoystick::get_button_count() const
 /////////////////////////////////////////////////////////////////////////////
 // InputDeviceProvider_LinuxJoystick operations:
 
-void InputDeviceProvider_LinuxJoystick::set_position(float x, float y)
-{
-	// Force feedback?
-}
-
 void InputDeviceProvider_LinuxJoystick::process_event(js_event event) const
 {
 	InputEvent input_event;
-	input_event.mouse_pos = Pointf(window->get_mouse_position());
+	input_event.mouse_pos = window->get_mouse_position();
+	input_event.mouse_dip_pos = Pointf(window->get_mouse_position()) / window->get_pixel_ratio();
 	input_event.repeat_count = 0;
 
 	// We don't threat JS_EVENT_INIT special, so this should do

--- a/Sources/Display/Platform/X11/input_device_provider_linuxjoystick.h
+++ b/Sources/Display/Platform/X11/input_device_provider_linuxjoystick.h
@@ -59,54 +59,31 @@ public:
 	/// \brief Get the file descriptor of the joystick
 	int get_fd() const;
 
-	/// \brief Returns the input device type.
 	InputDevice::Type get_type() const override { return InputDevice::joystick; }
 
-	/// \brief Returns the x position of the device.
-	float get_x() const override;
-
-	/// \brief Returns the y position of the device.
-	float get_y() const override;
-
-	/// \brief Returns true if the passed key code is down for this device.
 	bool get_keycode(int keycode) const override;
 
-	/// \brief Key name for specified identifier (A, B, C, Space, Enter, Backspace).
 	std::string get_key_name(int id) const override;
 
-	/// \brief Returns the the current position of a joystick axis.
 	float get_axis(int index) const override;
 
-	/// \brief Returns the name of the device (i.e. 'Microsoft Sidewinder 3D').
 	std::string get_name() const override;
 
-	/// \brief Return the hardware id/device for this device (i.e. /dev/input/js0)
 	std::string get_device_name() const override;
 
-	/// \brief Returns the number of axes available on this device.
 	std::vector<int> get_axis_ids() const override;
 
-	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
 	int get_button_count() const override;
-
-	/// \brief Tablet specific functionality.
-	bool in_proximity() const override { return false; }
 
 /// \}
 /// \name Operations
 /// \{
 
 public:
-	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>*/
 	void init(Signal<void(const InputEvent &)> *new_sig_provider_event) override
 	{
 		sig_provider_event = new_sig_provider_event;
 	}
-
-	/// \brief Sets the position of the device.
-	void set_position(float x, float y) override;
 
 	/// \brief Update device
 	///

--- a/Sources/Display/Platform/X11/input_device_provider_x11keyboard.cpp
+++ b/Sources/Display/Platform/X11/input_device_provider_x11keyboard.cpp
@@ -140,7 +140,8 @@ void InputDeviceProvider_X11Keyboard::received_keyboard_input(XKeyEvent &event)
 	else
 		key.type = InputEvent::released;
 
-	key.mouse_pos = Pointf(window->get_mouse_position());
+	key.mouse_pos = Point(window->get_mouse_position());
+	key.mouse_dip_pos = Pointf(window->get_mouse_position()) / window->get_pixel_ratio();
 
 	KeySym key_symbol = XkbKeycodeToKeysym(window->get_display(), key_code, 0, 0);
 

--- a/Sources/Display/Platform/X11/input_device_provider_x11keyboard.h
+++ b/Sources/Display/Platform/X11/input_device_provider_x11keyboard.h
@@ -59,41 +59,22 @@ public:
 /// \{
 
 public:
-	/// \brief Returns the input device type.
 	InputDevice::Type get_type() const override { return InputDevice::keyboard; }
 
-	/// \brief Returns true if the passed key code is down for this device.
 	bool get_keycode(int keycode) const override;
 
-	/// \brief Key name for specified identifier (A, B, C, Space, Enter, Backspace).
 	std::string get_key_name(int id) const override;
 
-	/// \brief Returns the the current position of a joystick axis.
 	float get_axis(int index) const override;
 
-	/// \brief Returns the name of the device (i.e. 'Microsoft Sidewinder 3D').
 	std::string get_name() const override;
 
-	/// \brief Return the hardware id/device for this device (i.e. /dev/input/js0)
 	std::string get_device_name() const override;
 
-	/// \brief Returns the number of axes available on this device.
 	std::vector<int> get_axis_ids() const override;
 
-	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
 	int get_button_count() const override;
 
-	/// \brief Returns the x position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	float get_x() const override { return 0.f; }
-
-	/// \brief Returns the y position of the device.
-	/** <p>Only valid for mouse.</p>*/
-	float get_y() const override { return 0.f; }
-
-	/// \brief Tablet specific functionality.
-	bool in_proximity() const override { return false; }
 
 	void get_keyboard_modifiers(bool &key_shift, bool &key_alt, bool &key_ctrl) const;
 
@@ -102,15 +83,10 @@ public:
 /// \{
 
 public:
-	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>*/
 	void init(Signal<void(const InputEvent &)> *new_sig_provider_event) override
 	{
 		sig_provider_event = new_sig_provider_event;
 	}
-
-	/// \brief Sets the position of the device.
-	void set_position(float x, float y) override { return; }
 
 	void received_keyboard_input(XKeyEvent &event);
 

--- a/Sources/Display/Platform/X11/input_device_provider_x11mouse.h
+++ b/Sources/Display/Platform/X11/input_device_provider_x11mouse.h
@@ -56,57 +56,39 @@ public:
 /// \{
 
 public:
-	/// \brief Returns the input device type.
 	InputDevice::Type get_type() const override { return InputDevice::pointer; }
 
-	/// \brief Returns the x position of the device.
-	float get_x() const override;
+	Point get_position() const override;
 
-	/// \brief Returns the y position of the device.
-	float get_y() const override;
+	Pointf get_dip_position() const override;
 
-	/// \brief Returns the x and y position of the device.
-	Pointf get_position() const;
-
-	/// \brief Returns true if the passed key code is down for this device.
 	bool get_keycode(int keycode) const override;
 
-	/// \brief Key name for specified identifier (A, B, C, Space, Enter, Backspace).
 	std::string get_key_name(int id) const override;
 
-	/// \brief Returns the the current position of a joystick axis.
 	float get_axis(int index) const override;
 
-	/// \brief Returns the name of the device (i.e. 'Microsoft Sidewinder 3D').
 	std::string get_name() const override;
 
-	/// \brief Return the hardware id/device for this device (i.e. /dev/input/js0)
 	std::string get_device_name() const override;
 
-	/// \brief Returns the number of axes available on this device.
 	std::vector<int> get_axis_ids() const override;
 
-	/// \brief Returns the number of buttons available on this device.
-	/** <p>If used on a keyboard, this function returns -1.</p>*/
 	int get_button_count() const override;
-
-	/// \brief Tablet specific functionality.
-	bool in_proximity() const override { return false; }
 
 /// \}
 /// \name Operations
 /// \{
 
 public:
-	/// \brief Initialize input device provider.
-	/** <p>The device field of InputEvent should not be set when emitting events.</p>*/
 	void init(Signal<void(const InputEvent &)> *new_sig_provider_event) override
 	{
 		sig_provider_event = new_sig_provider_event;
 	}
 
-	/// \brief Sets the position of the device.
-	void set_position(float x, float y) override;
+	void set_position(int x, int y) override;
+
+	void set_dip_position(float x, float y) override;
 
 	void received_mouse_input(XButtonEvent &event);
 	void received_mouse_move(XMotionEvent &event);

--- a/Sources/Display/Window/input_device.cpp
+++ b/Sources/Display/Window/input_device.cpp
@@ -403,28 +403,20 @@ bool InputDevice::get_keycode(int keycode) const
 		return false;
 }
 
-Pointf InputDevice::get_position() const
+Point InputDevice::get_position() const
 {
 	if (impl->provider)
-		return Pointf(impl->provider->get_x(), impl->provider->get_y());
+		return impl->provider->get_position();
+	else
+		return Point();
+}
+
+Pointf InputDevice::get_dip_position() const
+{
+	if (impl->provider)
+		return impl->provider->get_dip_position();
 	else
 		return Pointf();
-}
-
-float InputDevice::get_x() const
-{
-	if (impl->provider)
-		return impl->provider->get_x();
-	else
-		return 0.0f;
-}
-
-float InputDevice::get_y() const
-{
-	if (impl->provider)
-		return impl->provider->get_y();
-	else
-		return 0.0f;
 }
 
 float InputDevice::get_axis(int index) const
@@ -477,10 +469,16 @@ InputDevice &InputDevice::operator =(const InputDevice &copy)
 	return *this;
 }
 
-void InputDevice::set_position(float x, float y)
+void InputDevice::set_position(int x, int y)
 {
 	if (impl->provider)
 		impl->provider->set_position(x, y);
+}
+
+void InputDevice::set_dip_position(float x, float y)
+{
+	if (impl->provider)
+		impl->provider->set_dip_position(x, y);
 }
 
 /////////////////////////////////////////////////////////////////////////////

--- a/Sources/UI/StandardViews/texture_view_impl.cpp
+++ b/Sources/UI/StandardViews/texture_view_impl.cpp
@@ -191,12 +191,12 @@ namespace clan
 		Key key = decode_ic(e.id);
 		int repeat_count = e.repeat_count;
 		const std::string text = e.str;
-		const Pointf pointer_pos = e.mouse_pos;
+		const Pointf pointer_dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		KeyEvent key_event(type, key, repeat_count, text, pointer_pos, alt_down, shift_down, ctrl_down, cmd_down);
+		KeyEvent key_event(type, key, repeat_count, text, pointer_dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_key_event(key_event);
 	}
 
@@ -206,12 +206,12 @@ namespace clan
 		Key key = decode_ic(e.id);
 		int repeat_count = e.repeat_count;
 		const std::string text = e.str;
-		const Pointf pointer_pos = e.mouse_pos;
+		const Pointf pointer_dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		KeyEvent key_event(type, key, repeat_count, text, pointer_pos, alt_down, shift_down, ctrl_down, cmd_down);
+		KeyEvent key_event(type, key, repeat_count, text, pointer_dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_key_event(key_event);
 	}
 
@@ -219,12 +219,12 @@ namespace clan
 	{
 		PointerEventType type = PointerEventType::press;
 		PointerButton button = decode_id(e.id);
-		const Pointf pos = e.mouse_pos;
+		const Pointf dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		PointerEvent pointer_event(type, button, pos, alt_down, shift_down, ctrl_down, cmd_down);
+		PointerEvent pointer_event(type, button, dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_pointer_event(pointer_event);
 	}
 
@@ -232,12 +232,12 @@ namespace clan
 	{
 		PointerEventType type = PointerEventType::double_click;
 		PointerButton button = decode_id(e.id);
-		const Pointf pos = e.mouse_pos;
+		const Pointf dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		PointerEvent pointer_event(type, button, pos, alt_down, shift_down, ctrl_down, cmd_down);
+		PointerEvent pointer_event(type, button, dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_pointer_event(pointer_event);
 	}
 
@@ -245,18 +245,18 @@ namespace clan
 	{
 		PointerEventType type = PointerEventType::release;
 		PointerButton button = decode_id(e.id);
-		const Pointf pos = e.mouse_pos;
+		const Pointf dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		PointerEvent pointer_event(type, button, pos, alt_down, shift_down, ctrl_down, cmd_down);
+		PointerEvent pointer_event(type, button, dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_pointer_event(pointer_event);
 	}
 
 	void TextureView_Impl::on_mouse_move(const clan::InputEvent &clan_event)
 	{
-		PointerEvent e(PointerEventType::move, PointerButton::none, clan_event.mouse_pos, clan_event.alt, clan_event.shift, clan_event.ctrl, false/*clan_event.cmd*/);
+		PointerEvent e(PointerEventType::move, PointerButton::none, clan_event.mouse_dip_pos, clan_event.alt, clan_event.shift, clan_event.ctrl, false/*clan_event.cmd*/);
 		window_pointer_event(e);
 	}
 

--- a/Sources/UI/StandardViews/texture_view_impl.h
+++ b/Sources/UI/StandardViews/texture_view_impl.h
@@ -78,7 +78,7 @@ namespace clan
 		void transform_on_mouse_up(const clan::InputEvent &);
 		void transform_on_mouse_move(const clan::InputEvent &);
 
-		clan::InputEvent transform_input_event(const clan::InputEvent &event) { InputEvent e = event; e.mouse_pos = Vec2f(transform_mouse_matrix.get_transformed_point(Vec3f(e.mouse_pos.x, e.mouse_pos.y, 0))); return e; }
+		clan::InputEvent transform_input_event(const clan::InputEvent &event) { InputEvent e = event; e.mouse_dip_pos = Vec2f(transform_mouse_matrix.get_transformed_point(Vec3f(e.mouse_dip_pos.x, e.mouse_dip_pos.y, 0))); return e; }
 
 		int capture_down_counter = 0;
 		std::shared_ptr<View> captured_view;

--- a/Sources/UI/StandardViews/window_view_impl.cpp
+++ b/Sources/UI/StandardViews/window_view_impl.cpp
@@ -114,6 +114,8 @@ namespace clan
 
 	void WindowView_Impl::window_pointer_event(PointerEvent &e)
 	{
+		e.set_pos(window_view, e.pos(window_view) - window_view->geometry().content.get_top_left());
+
 		std::shared_ptr<View> view_above_cursor = window_view->find_view_at(e.pos(window_view));
 
 		if (view_above_cursor != hot_view)
@@ -170,12 +172,12 @@ namespace clan
 		Key key = decode_ic(e.id);
 		int repeat_count = e.repeat_count;
 		const std::string text = e.str;
-		const Pointf pointer_pos = e.mouse_pos;
+		const Pointf pointer_dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		KeyEvent key_event(type, key, repeat_count, text, pointer_pos, alt_down, shift_down, ctrl_down, cmd_down);
+		KeyEvent key_event(type, key, repeat_count, text, pointer_dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_key_event(key_event);
 	}
 
@@ -185,12 +187,12 @@ namespace clan
 		Key key = decode_ic(e.id);
 		int repeat_count = e.repeat_count;
 		const std::string text = e.str;
-		const Pointf pointer_pos = e.mouse_pos;
+		const Pointf pointer_dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		KeyEvent key_event(type, key, repeat_count, text, pointer_pos, alt_down, shift_down, ctrl_down, cmd_down);
+		KeyEvent key_event(type, key, repeat_count, text, pointer_dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_key_event(key_event);
 	}
 
@@ -198,12 +200,12 @@ namespace clan
 	{
 		PointerEventType type = PointerEventType::press;
 		PointerButton button = decode_id(e.id);
-		const Pointf pos = e.mouse_pos;
+		const Pointf dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		PointerEvent pointer_event(type, button, pos, alt_down, shift_down, ctrl_down, cmd_down);
+		PointerEvent pointer_event(type, button, dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_pointer_event(pointer_event);
 	}
 
@@ -211,12 +213,12 @@ namespace clan
 	{
 		PointerEventType type = PointerEventType::double_click;
 		PointerButton button = decode_id(e.id);
-		const Pointf pos = e.mouse_pos;
+		const Pointf dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		PointerEvent pointer_event(type, button, pos, alt_down, shift_down, ctrl_down, cmd_down);
+		PointerEvent pointer_event(type, button, dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_pointer_event(pointer_event);
 	}
 
@@ -224,18 +226,18 @@ namespace clan
 	{
 		PointerEventType type = PointerEventType::release;
 		PointerButton button = decode_id(e.id);
-		const Pointf pos = e.mouse_pos;
+		const Pointf dip_pos = e.mouse_dip_pos;
 		bool alt_down = e.alt;
 		bool shift_down = e.shift;
 		bool ctrl_down = e.ctrl;
 		bool cmd_down = false;
-		PointerEvent pointer_event(type, button, pos, alt_down, shift_down, ctrl_down, cmd_down);
+		PointerEvent pointer_event(type, button, dip_pos, alt_down, shift_down, ctrl_down, cmd_down);
 		window_pointer_event(pointer_event);
 	}
 
 	void WindowView_Impl::on_mouse_move(const clan::InputEvent &clan_event)
 	{
-		PointerEvent e(PointerEventType::move, PointerButton::none, clan_event.mouse_pos, clan_event.alt, clan_event.shift, clan_event.ctrl, false/*clan_event.cmd*/);
+		PointerEvent e(PointerEventType::move, PointerButton::none, clan_event.mouse_dip_pos, clan_event.alt, clan_event.shift, clan_event.ctrl, false/*clan_event.cmd*/);
 		window_pointer_event(e);
 	}
 


### PR DESCRIPTION
The unit used for mouse positioning was switched from Device Dependent Pixel (hardware pixel unit) to Device Independent Pixel (DPI-scaled pixel unit) in the DPR patch on January. This commit brings back DDP positioning for pointing devices and adds DIP positioning into clan::InputDevice as separate functions.

- `InputDevice::get_position()` and `InputEvent::mouse_pos` are in integer hardware pixel units like in ClanLib 3.x.
- `InputDevice::get_dip_position()` and `InputEvent::mouse_dip_pos` are in the new floating-point DIP pixel unit.

Note that the UI API has not changed at all; the module still uses DIP unit on everything. PointerEvent's pos() and set_pos() uses the DIP unit.

P/S: Implemented for Linux and Windows; only tested on Linux. I also removed Doxygen comments and added override keyword on the member functions of InputDeviceProvider implementors