### PR TITLE
Prevent D3D to process alt+enter messages

### DIFF
--- a/Sources/D3D/d3d_display_window_provider.cpp
+++ b/Sources/D3D/d3d_display_window_provider.cpp
@@ -257,6 +257,20 @@ void D3DDisplayWindowProvider::create(DisplayWindowSite *new_site, const Display
 
 	create_swap_chain_buffers();
 
+	// Prevent DXGI from responding to an alt-enter sequence.
+	ComPtr<IDXGIAdapter> dxgi_adapter;
+	result = dxgi_device->GetParent(__uuidof(IDXGIAdapter), (void **)&dxgi_adapter);
+	if (!result)
+	{
+		ComPtr<IDXGIFactory> dxgi_factory;
+		result = dxgi_adapter->GetParent(__uuidof(IDXGIFactory), (void **)&dxgi_factory);
+		if (!result)
+		{
+			dxgi_factory->MakeWindowAssociation(window.get_hwnd(), DXGI_MWA_NO_ALT_ENTER);
+		}
+	}
+
+
 	gc = GraphicContext(new D3DGraphicContextProvider(this, description));
 
 	if (description.is_fullscreen())


### PR DESCRIPTION
D3D target has an unpleasant feature by default - it seeks for alt+enter
sequence and process it before these messages got dispatched to the
actual program. It comes to a nasty effect of having alt+enter
fullscreen mode without programmer knowing about it.
This is a fix for it.