### PR TITLE
Dummy implementations of toggle_fullscreen()

### DIFF
--- a/Sources/GL/Platform/AGL/opengl_window_provider_agl.h
+++ b/Sources/GL/Platform/AGL/opengl_window_provider_agl.h
@@ -114,6 +114,7 @@ public:
 	void minimize() { cocoa_window.minimize(); }
 	void restore() { cocoa_window.restore(); }
 	void maximize() { cocoa_window.maximize(); }
+	void toggle_fullscreen() { } // FIXME: real implementation
 	void show(bool activate)  { cocoa_window.show(activate); }
 	void hide() { cocoa_window.hide(); }
 	void bring_to_front() { cocoa_window.bring_to_front(); }

--- a/Sources/GL/Platform/Android/opengl_window_provider_android.cpp
+++ b/Sources/GL/Platform/Android/opengl_window_provider_android.cpp
@@ -351,6 +351,10 @@ namespace clan
 	{
 	}
 
+	void OpenGLWindowProvider::toggle_fullscreen()
+	{
+	}
+
 	void OpenGLWindowProvider::show(bool activate)
 	{
 	}

--- a/Sources/GL/Platform/Android/opengl_window_provider_android.h
+++ b/Sources/GL/Platform/Android/opengl_window_provider_android.h
@@ -107,6 +107,7 @@ namespace clan
 		void minimize() override;
 		void restore() override;
 		void maximize() override;
+		void toggle_fullscreen() override;
 		void show(bool activate) override;
 		void hide() override;
 		void bring_to_front() override;

--- a/Sources/GL/Platform/GLX/opengl_window_provider_glx.h
+++ b/Sources/GL/Platform/GLX/opengl_window_provider_glx.h
@@ -245,6 +245,7 @@ public:
 	void minimize() override { x11_window.minimize(); }
 	void restore() override { x11_window.restore(); }
 	void maximize() override { x11_window.maximize(); }
+	void toggle_fullscreen() override { } // FIXME: real implementation
 	void show(bool activate) override  { x11_window.show(activate); }
 	void hide() override { x11_window.hide(); }
 	void bring_to_front() override { x11_window.bring_to_front(); }

--- a/Sources/GL/Platform/OSX/opengl_window_provider_osx.h
+++ b/Sources/GL/Platform/OSX/opengl_window_provider_osx.h
@@ -98,6 +98,7 @@ namespace clan
 		void minimize();
 		void restore();
 		void maximize();
+		void toggle_fullscreen();
 		void show(bool activate);
 		void hide();
 		void bring_to_front();

--- a/Sources/GL/Platform/OSX/opengl_window_provider_osx.mm
+++ b/Sources/GL/Platform/OSX/opengl_window_provider_osx.mm
@@ -317,6 +317,11 @@ namespace clan
 		[impl->window performZoom:impl->window];
 	}
 
+	void OpenGLWindowProvider::toggle_fullscreen()
+	{
+		// FIXME: real implementation
+	}
+
 	void OpenGLWindowProvider::show(bool activate)
 	{
 		if (activate)

--- a/Sources/GL/Platform/WGL/opengl_window_provider_wgl.h
+++ b/Sources/GL/Platform/WGL/opengl_window_provider_wgl.h
@@ -159,7 +159,7 @@ private:
 	HGLRC opengl_context;
 
 	/// \brief Device context for this window.
-    HDC device_context;
+	HDC device_context;
 	HWND shadow_hwnd = 0;
 	bool shadow_window;
 	bool dwm_layered;


### PR DESCRIPTION
New virtual method DisplayWindowProvider::toggle_fullscreen() prevents compiling on other platforms than Windows. These dummy implementations should make it compile on other platforms too.

I tested only with Linux, but I tried to obey the coding style of other platforms too, so it shouldn't break anything.