### PR TITLE
X11Window: Reduce set_viewport() calls to reduce resize flicker corruption

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,26 @@
 language: cpp
-before_install: sudo apt-get install libfreetype6-dev libjpeg-dev libmikmod2-dev libpng12-0-dev libvorbis-dev doxygen
+
 compiler:
   - gcc
   - clang
+
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - gcc-4.8
+            - g++-4.8
+            - clang
+            - libfreetype6-dev
+            - libjpeg-dev
+            - libmikmod2-dev
+            - libpng12-0-dev
+            - libvorbis-dev
+            - doxygen
+
+install:
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
 script:
   - ./autogen.sh

--- a/Sources/Display/Platform/X11/x11_window.h
+++ b/Sources/Display/Platform/X11/x11_window.h
@@ -208,7 +208,6 @@ private:
 	bool resize_enabled;
 	Clipboard_X11 clipboard;
 	std::vector<int> current_window_events;
-	std::vector<Rect> last_repaint_rect;
 	bool is_window_mapped;
 	XSizeHints *size_hints;
 
@@ -234,16 +233,22 @@ private:
 	int frame_size_bottom;
 	int border_width;
 
-	Rect current_window_client_area; // Set by ConfigureNotify event. Excludes window frame
-	Rect requested_current_window_client_area; // Excludes window frame. Requested from ClanLib before ConfigureNotify is called
+	Rect client_area; // Current window client area. Does not contain window frame.
 
-	const static int max_allowable_expose_events = 8;
+	/**
+	 * Contains `Rect`s obtained from X11 window resize events.
+	 * Elements stored are not used. Cleared on process_message_complete (once
+	 * all X11 events have been polled. Before it is cleared, a repaint of the
+	 * entire viewport is requested if it is not empty.
+	 */
+	std::vector<Rect> resize_event_rects;
 
-	bool always_send_window_position_changed_event;
-	bool always_send_window_size_changed_event;
-
-	std::vector<Rect> exposed_rects;
-	Rect largest_exposed_rect;
+	/**
+	 * Contains `Rect`s obtained from repaint request events.
+	 * Elements stored are used to call site->sig_paint().
+	 * Cleared on process_queued_events(), after process_message_complete().
+	 */
+	std::vector<Rect> repaint_event_rects;
 
 	float ppi           = 96.0f;
 	float pixel_ratio   = 0.0f;	// 0.0f = Unset


### PR DESCRIPTION
This is a workaround to reduce flickering corruption that happens when resizing the window. The changes are as follows:

- When polling X11 ConfigureNotify events, only the last resize event will be used to set the new window size. The entire viewport is then repainted.
- X11 Expose events now cause an immediate redraw instead of being cached in a buffer.
- When requesting a repaint, X11 Expose events are no longer created by ClanLib and then looped back over X11.
- Removed undocumented class members that looked redundant.

Note: It seems that window flickering when resizing very common problem; even `glxgears`has flickering problems when resizing. Most sources online recommend always re-drawing the entire screen when receiving the X11 Expose event (rather buffering them first) which implemented in the last commit.