### PR TITLE
Fix X support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,26 @@
 language: cpp
-before_install: sudo apt-get install libfreetype6-dev libjpeg-dev libmikmod2-dev libpng12-0-dev libvorbis-dev doxygen
+
 compiler:
   - gcc
   - clang
+
+addons:
+    apt:
+        sources:
+            - ubuntu-toolchain-r-test
+        packages:
+            - gcc-4.8
+            - g++-4.8
+            - clang
+            - libfreetype6-dev
+            - libjpeg-dev
+            - libmikmod2-dev
+            - libpng12-0-dev
+            - libvorbis-dev
+            - doxygen
+
+install:
+- if [ "$CXX" = "g++" ]; then export CXX="g++-4.8" CC="gcc-4.8"; fi
 
 script:
   - ./autogen.sh

--- a/Sources/API/Display/Window/display_window.h
+++ b/Sources/API/Display/Window/display_window.h
@@ -94,6 +94,7 @@ struct DisplayWindowHandle
 #else
 	::Display *display = 0;
 	::Window window = 0;
+	int screen = -1;
 #endif
 };
 

--- a/Sources/App/Unix/clanapp.cpp
+++ b/Sources/App/Unix/clanapp.cpp
@@ -32,6 +32,7 @@
 #include "API/Core/System/exception.h"
 #include "API/Core/System/console_window.h"
 #include "API/Core/Text/console.h"
+#include "API/Core/Text/console_logger.h"
 #include "API/display.h"
 
 namespace clan
@@ -39,20 +40,20 @@ namespace clan
 	static ApplicationInstancePrivate *app_instance = 0;
 	static bool enable_catch_exceptions = false;
 	static int timing_timeout = 0;
-	
+
 	static std::vector<std::string> command_line_args;
-	
+
 	ApplicationInstancePrivate::ApplicationInstancePrivate(bool catch_exceptions)
 	{
 		app_instance = this;
 		enable_catch_exceptions = catch_exceptions;
 	}
-	
+
 	const std::vector<std::string> &Application::main_args()
 	{
 		return command_line_args;
 	}
-	
+
 	void Application::use_timeout_timing(int timeout)
 	{
 		timing_timeout = timeout;
@@ -71,9 +72,14 @@ int main(int argc, char **argv)
 	for (int i = 0; i < argc; i++)
 		args.push_back(argv[i]);
 	clan::command_line_args = args;
-	
+
+#ifdef DEBUG
+	clan::ConsoleLogger console_logger;
+	console_logger.enable();
+#endif
+
 	int retval = 0;
-	
+
 	if (clan::enable_catch_exceptions)
 	{
 		try
@@ -85,7 +91,7 @@ int main(int argc, char **argv)
 				{
 					if (!app->update())
 						break;
-					
+
 					if (!clan::RunLoop::process(clan::timing_timeout))
 						break;
 				}
@@ -94,7 +100,7 @@ int main(int argc, char **argv)
 					std::string console_name("Console");
 					if (!args.empty())
 						console_name = args[0];
-					
+
 					clan::ConsoleWindow console(console_name, 80, 160);
 					clan::Console::write_line("Exception caught: " + exception.get_message_and_stack_trace());
 					console.display_close_message();
@@ -109,7 +115,7 @@ int main(int argc, char **argv)
 			std::string console_name("Console");
 			if (!args.empty())
 				console_name = args[0];
-			
+
 			clan::ConsoleWindow console(console_name, 80, 160);
 			clan::Console::write_line("Exception caught: " + exception.get_message_and_stack_trace());
 			console.display_close_message();
@@ -124,7 +130,7 @@ int main(int argc, char **argv)
 		{
 			if (!app->update())
 				break;
-			
+
 			if (!clan::RunLoop::process(clan::timing_timeout))
 				break;
 		}

--- a/Sources/Display/Makefile.am
+++ b/Sources/Display/Makefile.am
@@ -151,6 +151,7 @@ Font/FontEngine/font_engine_freetype.cpp \
 Platform/X11/display_message_queue_x11.cpp \
 Platform/X11/input_device_provider_x11keyboard.cpp \
 Platform/X11/clipboard_x11.cpp \
+Platform/X11/x11_atoms.cpp \
 Platform/X11/x11_window.cpp \
 Platform/X11/input_device_provider_x11mouse.cpp \
 Platform/X11/cursor_provider_x11.cpp

--- a/Sources/Display/Platform/X11/WMSupport.md
+++ b/Sources/Display/Platform/X11/WMSupport.md
@@ -1,0 +1,118 @@
+# X11 Window Manager Test Plan and Support Log
+
+## Rationale
+
+To make sure ClanLib's X11 implementation works on major standards-compliant
+windowing managers at all times.
+
+
+## Window Managers / Platforms Supported
+
+Use the Git blame tool to see when a particular WM was recorded here.
+
+- KDE 4.14.11
+  Status: Everything just works.
+
+- Xfce 4.12 (running Xfwm 4.12.3)
+  Status: Everything works, but `_NET_REQUEST_FRAME_EXTENTS` is malfunctioning
+          despite reportedly being fixed recently.
+
+
+## Test plan
+
+If something doesn't work right on your end, please go through the following
+test plan and report the problem numbers (i.e. ***1c***), your WM and any
+additional behaviour you find odd to us. It will help us track down the
+problem and fix it.
+
+Note that this test plan is only intended to test X11 window related problems.
+There could be bugs in the UI module that causes some of these problems and
+those problems are not tested or covered here.
+
+1. Run UI::HelloWorld Example.
+
+2. Move pointer over the button element and see if it responds to being hovered
+   over.
+
+    a. If a crash occurs as pointer is moving onto the window:
+       **Failure to process X11 events**
+
+    b. If a crash occurs as pointer is moving onto the button:
+       **Failure to create tooltip window**
+
+    c. If button look changes to a hovered look even though the pointer is
+       located **outside** of the button:
+       **X11 pointer motion event offset**
+
+       > Please check if offset is very similar to the lengths of the top-side
+       > and left-side decorator frames of the window. This would mean it is
+       > related to how the windowing system is offsetting the client area.
+
+    d. If the button (or other UI elements) does not change looks when hovered
+       over:
+       **X11 event polling failure** or **Window redraw failure**
+
+    e. If a tooltip does not appear when mouse is moved on to the button:
+       ***Known unfixed bug***
+
+3. Move and resize the window.
+
+    a. If contents of the window do not not change, despite the window now being
+       smaller or larger:
+       **Window redraw failure** or **Window resize failure**
+
+    b. If a crash occurs while or right after moving and/or resizing the window:
+       **X11 event polling failure** or **Window resize failure**
+
+    b. If the window moves or resizes unnaturally (not following the movement of
+       the pointer):
+       **X11 pointer motion event offset** or **Window reposition offset error**
+
+    c. Perform Step 2 again and check if problem "1c", "1d" and/or "1e" occurs.
+
+3. Click on the button on the main window.
+
+    a. If a crash occurs after button is pressed:
+       **Failure to create modal dialog**
+
+    b. If the modal dialog did not appear after button is pressed and the main
+       window no longer responds:
+       **Failure when creating modal dialog**
+
+    c. If the contents of modal dialog is a black background:
+       ***Known unfixed bug***. Please test if moving and/or resizing the dialog
+       causes the contents to be drawn.
+
+    d. Perform Step 3 on the dialog box and test if any of the problems occur.
+
+4. Click on the button on the dialog box. The dialog box should close.
+
+    a. If a crash occurs after pressing the button:
+       **Failure to unmap/delete dialog box**
+
+    b. If the button does not respond:
+       **X11 input event error.**
+
+5. Click on the button on the main window to create the dialog box again. Now,
+   close the window through your Window Manager (i.e. hit Alt+F4, click on Close
+   button on window frame, etc.).
+
+    a. If the window does not close:
+       **Failure to respond to window delete event.**
+
+    b. If a crash occurs when closing the dialog box:
+       **Failure to unmap/delete dialog box.**
+
+6. Test clipboard copy/paste support.
+
+   On the text-area, copy text with [Ctrl]+[C] and paste text with [Ctrl]+[V].
+   Only text is supported at the moment.
+
+7. Close the main window.
+
+    a. If the window does not close:
+       **Failure to respond to window delete event.**
+
+    b. If a crash occurs when closing the main window:
+       **Failure to unmap/delete main window.**
+

--- a/Sources/Display/Platform/X11/clipboard_x11.h
+++ b/Sources/Display/Platform/X11/clipboard_x11.h
@@ -70,9 +70,6 @@ private:
 	Atom atom_CLIPBOARD;
 	std::string clipboard_current;
 	bool clipboard_available;
-
-	::Display *disp;
-	::Window window;
 /// \}
 };
 

--- a/Sources/Display/Platform/X11/x11_atoms.cpp
+++ b/Sources/Display/Platform/X11/x11_atoms.cpp
@@ -1,0 +1,120 @@
+/*
+**  ClanLib SDK
+**  Copyright (c) 1997-2015 The ClanLib Team
+**
+**  This software is provided 'as-is', without any express or implied
+**  warranty.  In no event will the authors be held liable for any damages
+**  arising from the use of this software.
+**
+**  Permission is granted to anyone to use this software for any purpose,
+**  including commercial applications, and to alter it and redistribute it
+**  freely, subject to the following restrictions:
+**
+**  1. The origin of this software must not be misrepresented; you must not
+**     claim that you wrote the original software. If you use this software
+**     in a product, an acknowledgment in the product documentation would be
+**     appreciated but is not required.
+**  2. Altered source versions must be plainly marked as such, and must not be
+**     misrepresented as being the original software.
+**  3. This notice may not be removed or altered from any source distribution.
+**
+**  Note: Some of the libraries ClanLib may link to may have additional
+**  requirements or restrictions.
+**
+**  File Author(s):
+**
+**    Chu Chin Kuan
+*/
+#include "x11_atoms.h"
+
+namespace clan
+{
+
+const std::vector< std::string > X11Atoms::_atoms_ =
+{
+	"WM_PROTOCOLS",
+
+	"WM_DELETE_WINDOW",
+	"WM_STATE",
+
+
+	"_NET_FRAME_EXTENTS",
+
+	//! Requests the WM to calculate frame extents of the window at its current
+	//! configuration. Some WMs have _NET_FRAME_EXTENTS set anyway and do not
+	//! support this atom.
+	"_NET_REQUEST_FRAME_EXTENTS",
+
+
+	"_NET_WM_PING",
+
+	"_NET_WM_STATE", //! Set by WM, lists the following atoms:
+	"_NET_WM_STATE_HIDDEN",
+	"_NET_WM_STATE_FULLSCREEN",
+	"_NET_WM_STATE_MAXIMIZED_HORZ",
+	"_NET_WM_STATE_MAXIMIZED_VERT",
+	"_NET_WM_STATE_MODAL",
+
+	"_NET_WM_FULLSCREEN_MONITORS",
+
+
+	"_NET_WM_WINDOW_TYPE",
+
+	"_NET_WM_WINDOW_TYPE_DESKTOP",
+	"_NET_WM_WINDOW_TYPE_DOCK",
+	"_NET_WM_WINDOW_TYPE_TOOLBAR",
+	"_NET_WM_WINDOW_TYPE_MENU",
+	"_NET_WM_WINDOW_TYPE_UTILITY",
+	"_NET_WM_WINDOW_TYPE_SPLASH",
+	"_NET_WM_WINDOW_TYPE_DIALOG",
+	"_NET_WM_WINDOW_TYPE_DROPDOWN_MENU",
+	"_NET_WM_WINDOW_TYPE_POPUP_MENU",
+	"_NET_WM_WINDOW_TYPE_TOOLTIP",
+	"_NET_WM_WINDOW_TYPE_NOTIFICATION",
+	"_NET_WM_WINDOW_TYPE_COMBO",
+	"_NET_WM_WINDOW_TYPE_DND",
+	"_NET_WM_WINDOW_TYPE_NORMAL"
+};
+
+unsigned char *X11Atoms::get_property(::Display *display, Window window, Atom property, Atom &actual_type, int &actual_format, unsigned long &item_count)
+{
+	/* IO */ long  read_bytes = 0; // Request 0 bytes first.
+	Atom _actual_type = actual_type;
+	int  _actual_format = actual_format;
+	unsigned long _item_count = item_count;
+	unsigned long  bytes_remaining;
+	unsigned char *read_data  = NULL;
+
+	do
+	{
+		int result = XGetWindowProperty(
+				display, window, property, 0ul, read_bytes,
+				False, AnyPropertyType, &actual_type, &actual_format,
+				&_item_count, &bytes_remaining, &read_data
+				);
+
+		if (result != Success)
+		{
+			actual_type = None;
+			actual_format = 0;
+			item_count = 0;
+			return NULL;
+		}
+
+		read_bytes = bytes_remaining;
+	} while (bytes_remaining > 0);
+
+	item_count = _item_count;
+	return read_data;
+}
+
+unsigned char *X11Atoms::get_property(::Display *display, Window window, Atom property, unsigned long &item_count)
+{
+	Atom _actual_type;
+	int  _actual_format;
+
+	return X11Atoms::get_property(display, window, property, _actual_type, _actual_format, item_count);
+}
+
+
+}

--- a/Sources/Display/Platform/X11/x11_atoms.h
+++ b/Sources/Display/Platform/X11/x11_atoms.h
@@ -1,0 +1,199 @@
+/*
+**  ClanLib SDK
+**  Copyright (c) 1997-2015 The ClanLib Team
+**
+**  This software is provided 'as-is', without any express or implied
+**  warranty.  In no event will the authors be held liable for any damages
+**  arising from the use of this software.
+**
+**  Permission is granted to anyone to use this software for any purpose,
+**  including commercial applications, and to alter it and redistribute it
+**  freely, subject to the following restrictions:
+**
+**  1. The origin of this software must not be misrepresented; you must not
+**     claim that you wrote the original software. If you use this software
+**     in a product, an acknowledgment in the product documentation would be
+**     appreciated but is not required.
+**  2. Altered source versions must be plainly marked as such, and must not be
+**     misrepresented as being the original software.
+**  3. This notice may not be removed or altered from any source distribution.
+**
+**  Note: Some of the libraries ClanLib may link to may have additional
+**  requirements or restrictions.
+**
+**  File Author(s):
+**
+**    Chu Chin Kuan
+*/
+#include <algorithm>
+#include <cassert>
+#include <cstring> // memset
+#include <map>
+#include <string>
+#include <vector>
+#include <X11/Xlib.h>
+#include <X11/Xutil.h>
+
+#include "API/Core/Text/logger.h"
+
+namespace clan
+{
+
+using X11AtomMap = std::map< std::string, Atom >;
+
+class X11Atoms
+{
+public:
+	X11Atoms() : _display_(nullptr) {  }
+	X11Atoms(::Display *display) : _display_(display)
+	{
+		log_event("debug", "Initializing X11 Display Atoms...");
+		for (const auto &elem : _atoms_)
+		{
+			_map_[elem] = XInternAtom(_display_, elem.c_str(), True);
+			log_event("debug", "  %1\t: %2", elem, (_map_[elem] == None) ? "None" : "OK");
+		}
+	}
+
+	Atom &operator[](const std::string &elem)
+	{
+		auto iter = _map_.find(elem);
+		assert(iter != _map_.end());
+		return iter->second;
+	}
+
+	const Atom &operator[](const std::string &elem) const
+	{
+		auto iter = _map_.find(elem);
+		assert(iter != _map_.end());
+		return iter->second;
+	}
+
+	bool exists(const std::string &elem) const
+	{
+		auto iter = _map_.find(elem);
+		if (iter != _map_.end())
+			return iter->second != None;
+		else
+			return false;
+	}
+
+	Atom get_atom(::Display *display, const char *elem, bool only_if_exists)
+	{
+		assert(display == _display_); // Safety check.
+		auto iter = _map_.find(elem);
+		if (iter != _map_.end())
+		{
+			return iter->second;
+		}
+		else
+		{
+			Atom atom = XInternAtom(display, elem, only_if_exists);
+			_map_[std::string(elem)] = atom;
+			return atom;
+		}
+	}
+
+	void clear()
+	{
+		_map_.clear();
+	}
+
+	// Important: Use XFree() on the returned pointer (if not NULL)
+	static unsigned char *get_property(::Display *display, Window window, Atom property, Atom &actual_type, int &actual_format, unsigned long &item_count);
+	static unsigned char *get_property(::Display *display, Window window, Atom property, unsigned long &item_count);
+	unsigned char *get_property(Window window, const std::string &property, unsigned long &item_count) const
+	{
+		return get_property(_display_, window, (*this)[property], item_count);
+	}
+
+	//////////////////////////
+	// _NET_WM_STATE methods
+	//////////////////////////
+	std::vector<bool> check_net_wm_state(Window window, std::vector<std::string> state_atoms) const
+	{
+		// Atom not in _NET_WM_STATE MUST be considered not set.
+		std::vector< bool > states(state_atoms.size(), false);
+
+		if ((*this)["_NET_WM_STATE"] == None)
+		{
+			log_event("debug", "clan::X11Window::check_net_wm_state(): _NET_WM_STATE not provided by WM.");
+			return states;
+		}
+
+		// Get window states from WM
+		unsigned long  item_count;
+		unsigned char *data = get_property(window, "_NET_WM_STATE", item_count);
+		if (data == NULL)
+		{
+			log_event("debug", "clan::X11Atoms::check_net_wm_state(): Failed to query _NET_WM_STATE.");
+			return states;
+		}
+
+		unsigned long *items = (unsigned long *)data;
+
+		// Map each state atom to state boolean.
+		for (size_t i = 0; i < state_atoms.size(); i++)
+		{
+			const std::string &elem = state_atoms[i];
+			Atom state = static_cast<unsigned long>((*this)[elem]);
+			if (state == None)
+			{
+				log_event("debug", "clan::X11Atoms::check_net_wm_state(): %1 is not provided by WM.", elem);
+				continue; // Unsupported states are not queried.
+			}
+
+			auto it = std::find(items, items + item_count, state);
+			states[i] = (it != items + item_count);
+		}
+
+		XFree(data);
+		return states;
+	}
+
+	bool modify_net_wm_state(Window window, long action, const std::string &atom1, const std::string &atom2 = None)
+	{
+		Atom _NET_WM_STATE = (*this)["_NET_WM_STATE"];
+
+		if (_NET_WM_STATE == None)
+			return false;
+
+		XEvent xevent;
+		memset(&xevent, 0, sizeof(xevent));
+		xevent.xclient.type   = ClientMessage;
+		xevent.xclient.window = window;
+		xevent.xclient.message_type = _NET_WM_STATE;
+		xevent.xclient.format = 32;
+		xevent.xclient.data.l[0] =
+		xevent.xclient.data.l[1] = (*this)[atom1];
+		xevent.xclient.data.l[2] = (*this)[atom2];
+		xevent.xclient.data.l[3] = 0; // or 2
+
+		Status ret = XSendEvent(
+				_display_, DefaultRootWindow(_display_), False,
+				SubstructureNotifyMask | SubstructureRedirectMask, &xevent
+				);
+
+		XFlush(_display_);
+
+		if (ret == 0)
+		{
+			log_event("debug", "clan::X11Atoms::modify_net_wm_state(): XSendEvent failed.");
+			return false;
+		}
+		else
+		{
+			return true;
+		}
+	}
+
+public:
+	//! List of all atoms handled by ClanLib.
+	static const std::vector< std::string > _atoms_;
+
+private:
+	::Display* _display_;
+	X11AtomMap _map_;
+};
+
+}

--- a/Sources/Display/Platform/X11/x11_window.cpp
+++ b/Sources/Display/Platform/X11/x11_window.cpp
@@ -1133,8 +1133,6 @@ void X11Window::process_message(XEvent &event, X11Window *mouse_capture_window)
 			break;
 		case ButtonPress:
 		case ButtonRelease:
-			log_event("debug", "clan::X11Window::process_message: ButtonEvent received.");
-			log_event("debug", "    ButtonEvent: se%1 x%2 y%3 xr%4 yr%5 b%6", event.xmotion.send_event, event.xbutton.x, event.xbutton.y, event.xbutton.x_root, event.xbutton.y_root, event.xbutton.button);
 			if (mouse_capture_window->get_mouse() && event.xany.send_event==0)
 			{
 				if (callback_on_clicked)
@@ -1158,9 +1156,6 @@ void X11Window::process_message(XEvent &event, X11Window *mouse_capture_window)
 			}
 			break;
 		case MotionNotify:
-			log_event("debug", "clan::X11Window::process_message: MotionNotify received.");
-			log_event("debug", "    MotionEvent: se%1 x%2 y%3 xr%4 yr%5", event.xmotion.send_event, event.xmotion.x, event.xmotion.y, event.xmotion.x_root, event.xmotion.y_root);
-
 			if (mouse_capture_window->get_mouse() && event.xany.send_event == 0)
 			{
 				if (this != mouse_capture_window) // TODO What is this ???

--- a/Sources/Display/Platform/X11/x11_window.h
+++ b/Sources/Display/Platform/X11/x11_window.h
@@ -208,7 +208,6 @@ private:
 	bool resize_enabled;
 	Clipboard_X11 clipboard;
 	std::vector<int> current_window_events;
-	std::vector<Rect> last_repaint_rect;
 	bool is_window_mapped;
 	XSizeHints *size_hints;
 
@@ -234,16 +233,22 @@ private:
 	int frame_size_bottom;
 	int border_width;
 
-	Rect current_window_client_area; // Set by ConfigureNotify event. Excludes window frame
-	Rect requested_current_window_client_area; // Excludes window frame. Requested from ClanLib before ConfigureNotify is called
+	Rect client_area; // Current window client area. Does not contain window frame.
 
-	const static int max_allowable_expose_events = 8;
+	/**
+	 * Contains `Rect`s obtained from X11 window resize events.
+	 * Elements stored are not used. Cleared on process_message_complete (once
+	 * all X11 events have been polled. Before it is cleared, a repaint of the
+	 * entire viewport is requested if it is not empty.
+	 */
+	std::vector<Rect> resize_event_rects;
 
-	bool always_send_window_position_changed_event;
-	bool always_send_window_size_changed_event;
-
-	std::vector<Rect> exposed_rects;
-	Rect largest_exposed_rect;
+	/**
+	 * Contains `Rect`s obtained from repaint request events.
+	 * Elements stored are used to call site->sig_paint().
+	 * Cleared on process_queued_events(), after process_message_complete().
+	 */
+	std::vector<Rect> repaint_event_rects;
 
 	float ppi           = 96.0f;
 	float pixel_ratio   = 0.0f;	// 0.0f = Unset

--- a/Sources/Display/Platform/X11/x11_window.h
+++ b/Sources/Display/Platform/X11/x11_window.h
@@ -215,8 +215,6 @@ private:
 	Atom wm_delete_window;
 	Atom net_wm_ping;
 	Atom wm_state;
-	Atom motif_wm_hints;
-	Atom kwm_win_decoration;
 	Atom net_wm_state;
 	Atom net_wm_state_maximized_vert;
 	Atom net_wm_state_maximized_horz;

--- a/configure.ac
+++ b/configure.ac
@@ -89,16 +89,11 @@ AC_PROG_LIBTOOL
 
 dnl Using C++
 AC_LANG(C++)
-dnl AC_LANG(C)
-
-dnl Checks for header files.
-AC_HEADER_STDC
-AC_HEADER_STDBOOL
 
 dnl Find absolute name to pkg-config
 AC_PATH_PROG(PKG_CONFIG, pkg-config, no)
 
-CXXFLAGS="$CXXFLAGS -std=c++0x"
+CXXFLAGS="$CXXFLAGS -std=c++11"
 
 case $target in
 	*cygwin* )
@@ -180,17 +175,13 @@ if test -n "$use_extra_libs" && test "$use_extra_libs" != "NO"; then
 	IFS=$ac_save_ifs
 fi
 
-AC_CHECK_HEADERS(unistd.h fcntl.h sys/kd.h sys/vt.h sys/sysctl.h)
-AC_EGREP_HEADER(fcvt, stdlib.h,,AC_DEFINE(NEED_FCVT))
-
-dnl -----------------------------------------------------
-dnl Check commandline parameters to the configure script:
-dnl -----------------------------------------------------
-
+dnl -------------------------------------
+dnl Check system headers and definitions:
+dnl -------------------------------------
+AC_CHECK_HEADERS(unistd.h fcntl.h sys/times.h sys/types.h sys/stat.h sys/sysctl.h)
 AC_CHECK_HEADER(libgen.h)
-AC_CHECK_HEADER(sys/types.h)
-AC_CHECK_HEADER(fstab.h, AC_DEFINE([HAVE_FSTAB_H]))
 
+dnl Check if "extern const char *__progname" is available
 AC_MSG_CHECKING([for extern *__progname])
 AC_TRY_COMPILE([],
 [extern const char *__progname;],
@@ -200,6 +191,9 @@ AC_MSG_RESULT(no))
 dnl Check for GNU extensions
 AC_CHECK_FUNCS(wcscasecmp)
 
+dnl -----------------------------------------------------
+dnl Check commandline parameters to the configure script:
+dnl -----------------------------------------------------
 
 dnl -----------------------------------------------------
 dnl Check for optional SSE2 support:
@@ -437,8 +431,8 @@ if test "$enable_clanSound" != "no"; then
 	fi
 	
 	if test "$enable_clanSound" = "auto"; then enable_clanSound=yes; fi
-	AM_CONDITIONAL(ALSA, test x$have_alsa = xyes)
 fi
+AM_CONDITIONAL(ALSA, test "x$have_alsa" = "xyes")
 
 if test "$enable_clanNetwork" != "no"; then
 	echo "Checking for clanNetwork stuff"


### PR DESCRIPTION
Fix basic X and window manager support.

- Reduced the amount of `XMoveResize` calls by caching resize events.
- `Expose` events now cause the window to be immediately painted.
- Fixed AutoConf failure when `--disable-clanSound` is passed.
- Removed obsolete AutoConf tests.
- Dropped support for obsolete window managers and window manager hinting mechanisms.
- Moved all X Atom storage and handling code to a new class `X11Atoms`.
- Restructured X11 window creation code.
- Rewrote window typing / styling code.
- Removed illegal window state querying before window is mapped.
- Fixed and finished get/setters for min/max size.
- Fixed improper frame extents handling and all the quirks behind it.
- Made minimizing, maximizing and restoring update cache values.
- Fixed window mapping and unmapping logic.
- Fixed `get_screen_position()`.
- Fixed resize always being one event late.
- Fixed mouse pointer position calculation.
- Added screen number member to X11 `DisplayWindowHandle`.
- Added A LOT of logging code into `X11Window`.
- Added A LOT of documentation onto code.
- **Added a WM support log and test plan, `WMSupport.md`. Please try it out on your Linux system and report any problems you find here.**
- Unix apps now prints debug logs to screen if `DEBUG` is defined.

Known bug:
- HelloWorld dialog box shows up all black when created. I have not looked into it yet.

[![Build Status](https://travis-ci.org/keigen-shu/ClanLib.svg?branch=master)](https://travis-ci.org/keigen-shu/ClanLib)

Travis CI build log: https://travis-ci.org/keigen-shu/ClanLib/builds/79029837