### PR TITLE
Fix compilation error with ARM and musl libc

### DIFF
--- a/Sources/Core/System/system.cpp
+++ b/Sources/Core/System/system.cpp
@@ -43,7 +43,7 @@
 #include <sys/sysctl.h>
 #endif
 
-#if !defined __APPLE__ && !defined __ANDROID__
+#if defined HAVE_EXECINFO_H
 #include <execinfo.h>
 #endif
 #include <cxxabi.h>
@@ -135,7 +135,7 @@ namespace clan
 			*out_hash = 0;
 		return capturedFrames;
 
-#elif !defined __APPLE__ && !defined __ANDROID__
+#elif defined HAVE_EXECINFO_H
 		// Ensure the output is cleared
 		memset(out_frames, 0, (sizeof(void *)) * max_frames);
 
@@ -195,7 +195,7 @@ namespace clan
 		SymCleanup(GetCurrentProcess());
 		return backtrace_text;
 
-#elif !defined __APPLE__ && !defined __ANDROID__
+#elif defined HAVE_EXECINFO_H
 
 		char **strings;
 		strings = backtrace_symbols(frames, num_frames);

--- a/Sources/Sound/Platform/Linux/soundoutput_oss.cpp
+++ b/Sources/Sound/Platform/Linux/soundoutput_oss.cpp
@@ -44,9 +44,7 @@
 #ifdef HAVE_SOUNDCARD_H
 #include <soundcard.h>
 #endif
-#ifdef __CYGWIN__
 #include <sys/select.h>
-#endif
 
 #define DEFAULT_DSP "/dev/dsp"
 

--- a/configure.ac
+++ b/configure.ac
@@ -112,11 +112,11 @@ case $target in
 		;;
 esac
 
-dnl Define CL_ARM_PLATFORM if building for an ARM target
+dnl Define ARM_PLATFORM if building for an ARM target
 case $target in
 	arm* )
-		CXXFLAGS="$CXXFLAGS -DCL_ARM_PLATFORM"
-		CFLAGS="$CXXFLAGS -DCL_ARM_PLATFORM"
+		CXXFLAGS="$CXXFLAGS -DARM_PLATFORM"
+		CFLAGS="$CXXFLAGS -DARM_PLATFORM"
 		;;
 esac
 

--- a/configure.ac
+++ b/configure.ac
@@ -178,7 +178,7 @@ fi
 dnl -------------------------------------
 dnl Check system headers and definitions:
 dnl -------------------------------------
-AC_CHECK_HEADERS(unistd.h fcntl.h sys/times.h sys/types.h sys/stat.h sys/sysctl.h)
+AC_CHECK_HEADERS(unistd.h fcntl.h sys/times.h sys/types.h sys/stat.h sys/sysctl.h execinfo.h)
 AC_CHECK_HEADER(libgen.h)
 
 dnl Check if "extern const char *__progname" is available


### PR DESCRIPTION
Fix two compilation errors when using the musl c library (http://musl-libc.org) on linux. The fix for ARM could alternatively be done by changing the macros in detect_cpu_ext.cpp.