### PR TITLE
Fix MinGW

### DIFF
--- a/Examples/3D/VertexBuffer/Sources/app.cpp
+++ b/Examples/3D/VertexBuffer/Sources/app.cpp
@@ -35,7 +35,7 @@ clan::ApplicationInstance<App> clanapp;
 
 App::App()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/Alpha/Sources/alpha.cpp
+++ b/Examples/Display/Alpha/Sources/alpha.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<Alpha> clanapp;
 
 Alpha::Alpha()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/Basic2D/Sources/basic2d.cpp
+++ b/Examples/Display/Basic2D/Sources/basic2d.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<Basic2D> clanapp;
 
 Basic2D::Basic2D()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/Collision/Sources/collision.cpp
+++ b/Examples/Display/Collision/Sources/collision.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<CollisionApp> clanapp;
 
 CollisionApp::CollisionApp()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/DisplayTarget/Sources/program.cpp
+++ b/Examples/Display/DisplayTarget/Sources/program.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<Program> clanapp;
 
 Program::Program()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/DisplayTarget/Sources/target.cpp
+++ b/Examples/Display/DisplayTarget/Sources/target.cpp
@@ -46,9 +46,11 @@ Target::Target(RenderTarget new_target) : render_target(new_target)
 		opengl_desc.set_version(4, 3, true);
 		clan::OpenGLTarget::set_description(opengl_desc);
 		break;
+#if defined(WIN32) && !defined(__MINGW32__)
 	case (d3d) :
 		clan::D3DTarget::set_current();
 		break;
+#endif
 	}
 
 	clan::DisplayWindowDescription desc;
@@ -114,10 +116,14 @@ void Target::run_demo()
 		}
 	}
 
+#if defined(WIN32) && !defined(__MINGW32__)
 	if (clan::D3DTarget::is_current())
 			target_font.draw_text(canvas, font_xpos, font_ypos, "3) Direct3D renderer (clanD3D)");
 
 	fps_font.draw_text(canvas, 32, 96, "Press 1,2 or 3 to select targets, or escape to quit.");
+#else
+	fps_font.draw_text(canvas, 32, 96, "Press 1 or 2 to select targets, or escape to quit.");
+#endif
 
 	float max_height = (float) (canvas.get_height() + 20);
 	float half_height = (float) canvas.get_height() / 2.0f;
@@ -149,10 +155,12 @@ void Target::run_demo()
 	{
 		render_target = opengl;
 	}
+#if defined(WIN32) && !defined(__MINGW32__)
 	if (window.get_keyboard().get_keycode(clan::keycode_3))
 	{
 		render_target = d3d;
 	}
+#endif
 	if (window.get_keyboard().get_keycode(clan::keycode_escape))
 	{
 		quit = true;
@@ -199,5 +207,3 @@ void Target::on_window_close()
 {
 	quit = true;
 }
-
-

--- a/Examples/Display/FullScreen/Sources/fullscreen.cpp
+++ b/Examples/Display/FullScreen/Sources/fullscreen.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<FullScreen> clanapp;
 
 FullScreen::FullScreen()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/MultiWindow/Sources/example.cpp
+++ b/Examples/Display/MultiWindow/Sources/example.cpp
@@ -33,7 +33,7 @@ clan::ApplicationInstance<Example> clanapp;
 
 Example::Example()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/Particle/Sources/program.cpp
+++ b/Examples/Display/Particle/Sources/program.cpp
@@ -44,7 +44,7 @@ DemoState Program::state = DemoState::menu;
 
 Program::Program()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/Path/Sources/path.cpp
+++ b/Examples/Display/Path/Sources/path.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<PathApp> clanapp;
 
 PathApp::PathApp()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/SineScroll/Sources/sinescroll.cpp
+++ b/Examples/Display/SineScroll/Sources/sinescroll.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<SineScroll> clanapp;
 
 SineScroll::SineScroll()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/SvgViewer/Sources/svg_viewer.cpp
+++ b/Examples/Display/SvgViewer/Sources/svg_viewer.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<SvgViewer> clanapp;
 
 SvgViewer::SvgViewer()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/TextureGroup/Sources/atlas.cpp
+++ b/Examples/Display/TextureGroup/Sources/atlas.cpp
@@ -35,7 +35,7 @@ clan::ApplicationInstance<Atlas> clanapp;
 
 Atlas::Atlas()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/Thread/Sources/app.cpp
+++ b/Examples/Display/Thread/Sources/app.cpp
@@ -32,7 +32,7 @@ clan::ApplicationInstance<App> clanapp;
 
 App::App()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display/Timing/Sources/timing.cpp
+++ b/Examples/Display/Timing/Sources/timing.cpp
@@ -33,7 +33,7 @@ clan::ApplicationInstance<Timing> clanapp;
 
 Timing::Timing()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Render/Canvas/Sources/canvas.cpp
+++ b/Examples/Display_Render/Canvas/Sources/canvas.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<ExampleCanvas> clanapp;
 
 ExampleCanvas::ExampleCanvas()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Render/ColorWheel/Sources/app.cpp
+++ b/Examples/Display_Render/ColorWheel/Sources/app.cpp
@@ -35,7 +35,7 @@ clan::ApplicationInstance<App> clanapp;
 
 App::App()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Render/MapMode/Sources/app.cpp
+++ b/Examples/Display_Render/MapMode/Sources/app.cpp
@@ -35,7 +35,7 @@ clan::ApplicationInstance<App> clanapp;
 
 App::App()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Text/Font/Sources/font.cpp
+++ b/Examples/Display_Text/Font/Sources/font.cpp
@@ -33,7 +33,7 @@ clan::ApplicationInstance<App> clanapp;
 
 App::App()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Text/Language/Sources/language.cpp
+++ b/Examples/Display_Text/Language/Sources/language.cpp
@@ -52,7 +52,7 @@ clan::ApplicationInstance<Language> clanapp;
 
 Language::Language()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Text/Text/Sources/Text.cpp
+++ b/Examples/Display_Text/Text/Sources/Text.cpp
@@ -64,7 +64,7 @@ clan::ApplicationInstance<ExampleText> clanapp;
 
 ExampleText::ExampleText()
 {
-#ifdef WIN32
+#ifdef defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Text/Text/Sources/Text.cpp
+++ b/Examples/Display_Text/Text/Sources/Text.cpp
@@ -64,7 +64,7 @@ clan::ApplicationInstance<ExampleText> clanapp;
 
 ExampleText::ExampleText()
 {
-#ifdef defined(WIN32) && !defined(__MINGW32__)
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Display_Text/TextFade/Sources/textfade.cpp
+++ b/Examples/Display_Text/TextFade/Sources/textfade.cpp
@@ -34,7 +34,7 @@ clan::ApplicationInstance<TextFade> clanapp;
 
 TextFade::TextFade()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Input/Input/Sources/app.cpp
+++ b/Examples/Input/Input/Sources/app.cpp
@@ -33,7 +33,7 @@ clan::ApplicationInstance<App> clanapp;
 
 App::App()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Examples/Network/NetGame/MakeClient
+++ b/Examples/Network/NetGame/MakeClient
@@ -4,7 +4,7 @@ OBJF = \
 	Sources/Client/client.o \
 	Sources/Client/main.o
 
-LIBS=clanCore clanNetwork
+LIBS=clanNetwork clanCore
 
 CXXFLAGS += -I Sources/Client
 

--- a/Examples/Network/NetGame/MakeServer
+++ b/Examples/Network/NetGame/MakeServer
@@ -5,7 +5,7 @@ OBJF = \
 	Sources/Server/server_user.o \
 	Sources/Server/main.o
 
-LIBS=clanCore clanNetwork
+LIBS=clanNetwork clanCore
 
 CXXFLAGS += -I Sources/Server
 

--- a/Examples/Network/NetGame/Sources/Client/main.cpp
+++ b/Examples/Network/NetGame/Sources/Client/main.cpp
@@ -23,7 +23,13 @@ int main(int, char**)
 	catch (Exception e)
 	{
 #ifdef WIN32
-		MessageBox(0, e.get_message_and_stack_trace().c_str(), TEXT("Unhandled Exception"), MB_OK);	
+#ifdef UNICODE
+		std::string trace = e.get_message_and_stack_trace();
+		std::wstring wtrace(trace.begin(), trace.end());
+		MessageBox(0, wtrace.c_str(), TEXT("Unhandled Exception"), MB_OK);
+#else
+		MessageBox(0, e.get_message_and_stack_trace().c_str(), TEXT("Unhandled Exception"), MB_OK);
+#endif
 #else
 		Console::write_line("Unhandled exception: %1", e.get_message_and_stack_trace());
 #endif

--- a/Examples/Network/NetGame/Sources/Server/main.cpp
+++ b/Examples/Network/NetGame/Sources/Server/main.cpp
@@ -19,7 +19,13 @@ int main(int, char**)
 	catch (Exception e)
 	{
 #ifdef WIN32
-		MessageBox(0, e.get_message_and_stack_trace().c_str(), TEXT("Unhandled Exception"), MB_OK);	
+#ifdef UNICODE
+		std::string trace = e.get_message_and_stack_trace();
+		std::wstring wtrace(trace.begin(), trace.end());
+		MessageBox(0, wtrace.c_str(), TEXT("Unhandled Exception"), MB_OK);
+#else
+		MessageBox(0, e.get_message_and_stack_trace().c_str(), TEXT("Unhandled Exception"), MB_OK);
+#endif
 #else
 		Console::write_line("Unhandled exception: %1", e.get_message_and_stack_trace());
 #endif

--- a/Examples/Sound/Sound/Sources/app.cpp
+++ b/Examples/Sound/Sound/Sources/app.cpp
@@ -33,7 +33,7 @@ clan::ApplicationInstance<App> clanapp;
 
 App::App()
 {
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 	clan::D3DTarget::set_current();
 #else
 	clan::OpenGLTarget::set_current();

--- a/Setup/Unix/pkgconfig/clanApp.pc.in
+++ b/Setup/Unix/pkgconfig/clanApp.pc.in
@@ -9,6 +9,6 @@ Name: clanApp
 Description: portable main() wrapper of ClanLib
 Version: @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@App @extra_LIBS_clanApp@
-Cflags: -I${includedir}       @extra_CFLAGS_clanApp@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanApp@
 
 # EOF #

--- a/Setup/Unix/pkgconfig/clanCore.pc.in
+++ b/Setup/Unix/pkgconfig/clanCore.pc.in
@@ -10,6 +10,6 @@ Description: Core library of ClanLib
 Version: @VERSION@
 #Requires: clanSignals-@LT_RELEASE@ = @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@Core @extra_LIBS_clanCore@
-Cflags: -I${includedir} @extra_CFLAGS_clanCore@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanCore@
 
 # EOF #

--- a/Setup/Unix/pkgconfig/clanDisplay.pc.in
+++ b/Setup/Unix/pkgconfig/clanDisplay.pc.in
@@ -10,6 +10,6 @@ Description: Display support for ClanLib
 Version: @VERSION@
 Requires: clanCore-@LT_RELEASE@ = @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@Display @extra_LIBS_clanDisplay@
-Cflags: -I${includedir} @extra_CFLAGS_clanDisplay@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanDisplay@
 
 # EOF #

--- a/Setup/Unix/pkgconfig/clanGL.pc.in
+++ b/Setup/Unix/pkgconfig/clanGL.pc.in
@@ -10,6 +10,6 @@ Description: OpenGL display target of ClanLib
 Version: @VERSION@
 Requires: clanDisplay-@LT_RELEASE@ = @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@GL @extra_LIBS_clanGL@
-Cflags: -I${includedir} @extra_CFLAGS_clanGL@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanGL@
 
 # EOF #

--- a/Setup/Unix/pkgconfig/clanNetwork.pc.in
+++ b/Setup/Unix/pkgconfig/clanNetwork.pc.in
@@ -10,6 +10,6 @@ Description: Network support for ClanLib
 Version: @VERSION@
 #Requires: clanSignals-@LT_RELEASE@ = @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@Network @extra_LIBS_clanNetwork@
-Cflags: -I${includedir} @extra_CFLAGS_clanNetwork@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanNetwork@
 
 # EOF #

--- a/Setup/Unix/pkgconfig/clanSound.pc.in
+++ b/Setup/Unix/pkgconfig/clanSound.pc.in
@@ -10,6 +10,6 @@ Description: Sound support for ClanLib
 Version: @VERSION@
 Requires: clanCore-@LT_RELEASE@ = @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@Sound @extra_LIBS_clanSound@
-Cflags: -I${includedir} @extra_CFLAGS_clanSound@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanSound@
 
 # EOF #

--- a/Setup/Unix/pkgconfig/clanUI.pc.in
+++ b/Setup/Unix/pkgconfig/clanUI.pc.in
@@ -10,6 +10,6 @@ Description: UI support for ClanLib
 Version: @VERSION@
 Requires: clanDisplay-@LT_RELEASE@ = @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@UI @extra_LIBS_clanUI@
-Cflags: -I${includedir} @extra_CFLAGS_clanUI@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanUI@
 
 # EOF #

--- a/Setup/Unix/pkgconfig/clanXML.pc.in
+++ b/Setup/Unix/pkgconfig/clanXML.pc.in
@@ -10,6 +10,6 @@ Description: XML support for ClanLib
 Version: @VERSION@
 Requires: clanCore-@LT_RELEASE@ = @VERSION@
 Libs:   -L${libdir} -lclan@CLANLIB_RELEASE@XML @extra_LIBS_clanXML@
-Cflags: -I${includedir} @extra_CFLAGS_clanXML@
+Cflags: -I${includedir} @extra_CFLAGS_common@ @extra_CFLAGS_clanXML@
 
 # EOF #

--- a/Sources/API/Core/System/cl_platform.h
+++ b/Sources/API/Core/System/cl_platform.h
@@ -32,8 +32,7 @@
 #include <cstring>
 #include <cstdint>
 
-#ifdef WIN32
-// GCC automatically sets __SSE2__
+#ifndef __GNUC__ // GCC automatically sets __SSE2__
 #ifndef CL_DISABLE_SSE2
 #define __SSE__
 #define __SSE2__

--- a/Sources/API/Display/Font/font.h
+++ b/Sources/API/Display/Font/font.h
@@ -184,6 +184,8 @@ namespace clan
 	};
 
 	#ifdef WIN32
+	class FontEngine_Win32; // GCC needs to be explicitly told this is a class
+
 	class FontHandle_Win32 : public FontHandle
 	{
 	public:

--- a/Sources/API/d3d.h
+++ b/Sources/API/d3d.h
@@ -32,7 +32,7 @@
 
 #pragma once
 
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__)
 
 #ifdef __cplusplus_cli
 #pragma managed(push, off)

--- a/Sources/Core/Makefile.am
+++ b/Sources/Core/Makefile.am
@@ -142,7 +142,6 @@ Crypto/aes128_encrypt.cpp
 
 if WIN32
 libclan40Core_la_SOURCES += \
-System/Win32/init_win32.cpp \
 System/Win32/service_win32.cpp \
 IOData/Win32/directory_scanner_win32.cpp
 

--- a/Sources/Core/Makefile.am
+++ b/Sources/Core/Makefile.am
@@ -142,6 +142,7 @@ Crypto/aes128_encrypt.cpp
 
 if WIN32
 libclan40Core_la_SOURCES += \
+System/Win32/system_win32.cpp \
 System/Win32/service_win32.cpp \
 IOData/Win32/directory_scanner_win32.cpp
 

--- a/Sources/Display/Makefile.am
+++ b/Sources/Display/Makefile.am
@@ -126,7 +126,6 @@ Font/FontEngine/font_engine_win32.cpp \
 Platform/Win32/win32_window.cpp \
 Platform/Win32/screen_info_provider_win32.cpp \
 Platform/Win32/display_message_queue_win32.cpp \
-Platform/Win32/input_device_provider_win32tablet.cpp \
 Platform/Win32/input_device_provider_win32hid.cpp \
 Platform/Win32/hid.cpp \
 Platform/Win32/input_device_provider_win32mouse.cpp \

--- a/Sources/Display/Window/keys.cpp
+++ b/Sources/Display/Window/keys.cpp
@@ -56,9 +56,11 @@ namespace clan
 		case keycode_right: return Key::right;
 		case keycode_down: return Key::down;
 
+#if !defined(__CYGWIN__) && !defined(__MINGW32__)
 		case keycode_kanji: return Key::kanji;
 		case keycode_convert: return Key::convert;
 		case keycode_nonconvert: return Key::nonconvert;
+#endif
 
 		case keycode_help: return Key::help;
 

--- a/Sources/Display/setup_display.cpp
+++ b/Sources/Display/setup_display.cpp
@@ -98,7 +98,7 @@ namespace clan
 	SetupDisplay_Impl::SetupDisplay_Impl()
 	{
 		instance = this;
-#ifdef WIN32
+#if defined(WIN32) && !defined(__MINGW32__) // FIXME: Broken on MinGW (does not link)
 		SetProcessDPIAware();
 #endif
 

--- a/configure.ac
+++ b/configure.ac
@@ -104,7 +104,7 @@ case $target in
 	*mingw*)
 		X11="no"
 		WIN32="yes"
-		CXXFLAGS="$CXXFLAGS -DWIN32 -DUNICODE"
+		CXXFLAGS="$CXXFLAGS -DWIN32 -D_WIN32_WINNT=0x0600 -DUNICODE"
 		;;
 	*)
 		X11="yes"

--- a/configure.ac
+++ b/configure.ac
@@ -131,7 +131,7 @@ if test "$WIN32" = "yes"; then
 		extra_LIBS_clanApp="-lgdi32 -luser32 -lkernel32 -lmsvcrt"
 		extra_LIBS_clanCore="-lz -lmsvcrt -lshell32 -lshlwapi -lcomctl32 -lole32 -limagehlp -lmingwex"
 		extra_LIBS_clanDisplay="-lwinmm -lmsvcrt -lmingwex -lddraw -ldinput8 -ldxguid -lmapi32 -lgdi32 -lole32 -lfreetype"
-		extra_LIBS_clanSound="-ldsound -ldxguid -lwinmm -lmsvcrt -lmingwex"
+		extra_LIBS_clanSound="-ldsound -ldxguid -lksguid -luuid -lwinmm -lmsvcrt -lmingwex"
 		;;
 	*)
 		extra_CFLAGS_common="-mno-cygwin -DWIN32"

--- a/configure.ac
+++ b/configure.ac
@@ -122,25 +122,24 @@ esac
 
 dnl Extra flags that are needed to compile (for pkg-config)
 if test "$WIN32" = "yes"; then
+	extra_CFLAGS_clanApp="-mwindows"
+	extra_LIBS_clanGL="-lopengl32"
+	extra_LIBS_clanNetwork="-lws2_32"
 	case $target in
 	*mingw*)
-		extra_CFLAGS_clanApp="-mwindows"
+		extra_CFLAGS_common="-DWIN32 -D_WIN32_WINNT=0x0600 -DUNICODE"
 		extra_LIBS_clanApp="-lgdi32 -luser32 -lkernel32 -lmsvcrt"
 		extra_LIBS_clanCore="-lz -lmsvcrt -lshell32 -lshlwapi -lcomctl32 -lole32 -limagehlp -lmingwex"
 		extra_LIBS_clanDisplay="-lwinmm -lmsvcrt -lmingwex -lddraw -ldinput8 -ldxguid -lmapi32 -lgdi32 -lole32 -lfreetype"
-		extra_LIBS_clanGL="-lopengl32"
 		extra_LIBS_clanSound="-ldsound -ldxguid -lwinmm -lmsvcrt -lmingwex"
-		extra_LIBS_clanNetwork="-lws2_32"
 		;;
 	*)
-	extra_CFLAGS_clanApp="-mwindows"
-	extra_LIBS_clanCore="-lz"
-	extra_LIBS_clanDisplay="-lwinmm -lddraw -ldinput8 -ldxguid -lgdi32 -lole32"
-	extra_LIBS_clanGL="-lopengl32"
-	extra_LIBS_clanSound="-ldsound -ldxguid -lwinmm"
-	extra_LIBS_clanNetwork="-lws2_32"
-	;;
-esac
+		extra_CFLAGS_common="-mno-cygwin -DWIN32"
+		extra_LIBS_clanCore="-lz"
+		extra_LIBS_clanDisplay="-lwinmm -lddraw -ldinput8 -ldxguid -lgdi32 -lole32"
+		extra_LIBS_clanSound="-ldsound -ldxguid -lwinmm"
+		;;
+	esac
 fi
 
 dnl ----------------------------------------
@@ -473,6 +472,7 @@ fi
 dnl -----------------------------------------------------------------------
 dnl Store cflags for Setup/Unix/pkgconfig/clan*.in pkg-config files
 dnl -----------------------------------------------------------------------
+AC_SUBST(extra_CFLAGS_common)
 AC_SUBST(extra_CFLAGS_clanApp)
 AC_SUBST(extra_CFLAGS_clanCore)
 AC_SUBST(extra_CFLAGS_clanDisplay)

--- a/configure.ac
+++ b/configure.ac
@@ -125,8 +125,8 @@ if test "$WIN32" = "yes"; then
 	case $target in
 	*mingw*)
 		extra_CFLAGS_clanApp="-mwindows"
-		extra_LIBS_clanApp="-gdi32 -luser32 -lkernel32 -lmsvcrt"
-		extra_LIBS_clanCore="-lz -lmsvcrt -lshell32 -lshlwapi -limagehlp -lmingwex"
+		extra_LIBS_clanApp="-lgdi32 -luser32 -lkernel32 -lmsvcrt"
+		extra_LIBS_clanCore="-lz -lmsvcrt -lshell32 -lshlwapi -lcomctl32 -lole32 -limagehlp -lmingwex"
 		extra_LIBS_clanDisplay="-lwinmm -lmsvcrt -lmingwex -lddraw -ldinput8 -ldxguid -lmapi32 -lgdi32 -lole32 -lfreetype"
 		extra_LIBS_clanGL="-lopengl32"
 		extra_LIBS_clanSound="-ldsound -ldxguid -lwinmm -lmsvcrt -lmingwex"


### PR DESCRIPTION
Got all of ClanLib compiling and running under MinGW-W64 as best I can, except the Direct3D target isn't built. I used the examples as unit tests; DisplayTarget needed a little work to be able to go without Direct3D, and a few minor tweaks were needed besides (mostly revolving around D3D).

Skipped:

- 3D/Object3D and 3D/Quaternion (didn't want to deal with libassimp)
- UI/Controls and UI/MVC don't have a Makefile

Noted issues:

- Core/CpuExt fails to open a console window when run from the MSYS terminal. Fine if executed directly from explorer
- Display/Thread worker thread performance is quite bad, slow and stuttery (winpthread issue?)
- Display_Render/ColorWheel draw order is wrong
- Network/NetGame like CpuExt they fail to open their console windows when run from the MSYS terminal
- Sound/Sound sound is slightly distored, like a format conversion issue

All other tests are working fully and correctly as best I can tell.