### PR TITLE
Add property to LabelView::set_text(...bool force_no_layout = false)

### DIFF
--- a/Sources/API/UI/StandardViews/label_view.h
+++ b/Sources/API/UI/StandardViews/label_view.h
@@ -24,6 +24,7 @@
 **  File Author(s):
 **
 **    Magnus Norddahl
+**    Artem Khomenko (modified set_text())
 */
 
 #pragma once
@@ -62,7 +63,14 @@ namespace clan
 		LabelView();
 
 		std::string text() const;
-		void set_text(const std::string &value);
+		
+		/// \brief Set text for display to the user
+		///
+		/// \param value = Text
+		/// \param force_no_layout = when false or omitted, after setting the text occurs recalculate sizes 
+		/// and positions of elements, what means complete repaint the entire window. When true - simply drawing
+		/// the new text. Also make sure that the style property "background color" is set for this or its parents.
+		void set_text(const std::string &value, bool force_no_layout = false);
 
 		TextAlignment text_alignment() const;
 		void set_text_alignment(TextAlignment alignment);


### PR DESCRIPTION
Add default property to `LabelView::set_text(...bool force_no_layout = false)`.

When `force_no_layout = true` there is no invalidates and redraws all windows occurs. It helps to improve performance of user program (at least on MS Windows), for example when it needs to change text inside `bool App::update()`.

There is no changes in the behavior of existing programs.