### PR TITLE
Improved performance UI controls (clan::View and inherited).

### DIFF
--- a/Examples/Display/Thread/Sources/app.cpp
+++ b/Examples/Display/Thread/Sources/app.cpp
@@ -106,7 +106,13 @@ bool App::update()
 
 	canvas.clear();
 			
-	// If the pixel buffer was uploaded on the last frame, double buffer it
+	// If the pixel buffer was uploaded on the last frame, double buffer it.
+	// We use buffering texture to avoid the awaiting of GPU at the following situation: 
+	// 1. When we call texture->set_subimage() we tell the GPU driver to upload the pixelbuffer.
+	// 2. If internally the GPU is already using the texture (to draw the current frame), 
+	//		the videodriver has 2 options: wait, or defer copying (copy memory to a transfer buffer).
+	//		This wastes CPU cycles.
+	// PS It is possible that the latest graphics cards and drivers no longer have this performance issue.
 	if (texture_write_active)
 	{
 		texture_write_active = false;

--- a/Examples/Display_Shaders/ShaderEffect/program.cpp
+++ b/Examples/Display_Shaders/ShaderEffect/program.cpp
@@ -9,11 +9,11 @@ clan::ApplicationInstance<Program> clanapp;
 
 Program::Program()
 {
-	// We support all display targets, in order listed here
 	clan::OpenGLTarget::set_current();
 
 	window = DisplayWindow("Hello ShaderEffect", 1024, 1024, false, true);
 	sc.connect(window.sig_window_close(), [&](){exit = true; });
+	sc.connect(window.get_keyboard().sig_key_up(), clan::bind_member(this, &Program::on_input_up));
 
 	gc = window.get_gc();
 
@@ -60,4 +60,12 @@ bool Program::update()
 }
 
 
+// A key was pressed
+void Program::on_input_up(const clan::InputEvent &key)
+{
+	if (key.id == clan::keycode_escape)
+	{
+		exit = true;
+	}
+}
 

--- a/Examples/Display_Shaders/ShaderEffect/program.h
+++ b/Examples/Display_Shaders/ShaderEffect/program.h
@@ -20,6 +20,8 @@ public:
 		int xparticle_count;
 	};
 
+	void on_input_up(const clan::InputEvent &key);
+
 	clan::DisplayWindow window;
 	clan::SlotContainer sc;
 	clan::GraphicContext gc;

--- a/Examples/UI/FileDialogs/FileDialogs-vc2015.vcxproj
+++ b/Examples/UI/FileDialogs/FileDialogs-vc2015.vcxproj
@@ -109,6 +109,8 @@
       <WarningLevel>Level3</WarningLevel>
       <Optimization>Disabled</Optimization>
       <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -148,6 +150,8 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
+      <PrecompiledHeader>Create</PrecompiledHeader>
+      <PrecompiledHeaderFile>precomp.h</PrecompiledHeaderFile>
     </ClCompile>
     <Link>
       <EnableCOMDATFolding>true</EnableCOMDATFolding>

--- a/Examples/UI/FileDialogs/Sources/app.cpp
+++ b/Examples/UI/FileDialogs/Sources/app.cpp
@@ -47,15 +47,19 @@ App::App()
 	clan::OpenGLTarget::set_current();
 #endif
 
-	clan::Application::use_timeout_timing(std::numeric_limits<int>::max());	// The update() loop is not required for this application
-
 	// Create a window:
 	DisplayWindowDescription desc;
 	desc.set_title("UICore: Hello World");
 	desc.set_allow_resize(true);
 	window = std::make_shared<TopLevelWindow>(desc);
-	const std::shared_ptr<View> &root_view = window->root_view();
-	root_view->slots.connect(window->root_view()->sig_close(), [&](CloseEvent &e) { RunLoop::exit(); });
+	auto pRootView = window->root_view();
+	pRootView->slots.connect(window->root_view()->sig_close(), [&](CloseEvent &e) { RunLoop::exit(); });
+	pRootView->slots.connect(pRootView->sig_key_press(), [&](clan::KeyEvent &e)
+	{ if (e.key() == clan::Key::escape) RunLoop::exit(); }
+	);
+
+	// Need for receive a keyboard events.
+	pRootView->set_focus();
 
 	// Create a source for our resources
 	FileResourceDocument doc(FileSystem("../../ThemeAero"));
@@ -65,9 +69,9 @@ App::App()
 	ui_thread = UIThread(resources);
 
 	// Style the root view to use rounded corners and a bit of drop shadow
-	root_view->style()->set("padding: 11px");
-	root_view->style()->set("background: #efefef");
-	root_view->style()->set("flex-direction: column");
+	pRootView->style()->set("padding: 11px");
+	pRootView->style()->set("background: #efefef");
+	pRootView->style()->set("flex-direction: column");
 
 	// First (top) panel with button and text
 	//
@@ -76,14 +80,14 @@ App::App()
 	panel1->style()->set("padding: 11px");
 	panel1->style()->set("flex-direction: row");
 	panel1->style()->set("flex: auto");
-	root_view->add_child(panel1);
+	pRootView->add_child(panel1);
 
 	auto button1 = Theme::create_button();
 	button1->style()->set("height: 40px");
 	button1->style()->set("width: 120px");
 	button1->label()->set_text("Folder browse");
 	button1->style()->set("flex: none");
-	button1->image_view()->set_image(clan::Image(root_view->canvas(), "./document_open.png"));
+	button1->image_view()->set_image(clan::Image(pRootView->canvas(), "./document_open.png"));
 	button1->func_clicked() = clan::bind_member(this, &App::on_button1_down);
 	panel1->add_child(button1);
 
@@ -100,7 +104,7 @@ App::App()
 	panel2->style()->set("padding: 11px");
 	panel2->style()->set("flex-direction: row");
 	panel2->style()->set("flex: auto");
-	root_view->add_child(panel2);
+	pRootView->add_child(panel2);
 
 	auto button2 = Theme::create_button();
 	button2->style()->set("height: 40px");
@@ -123,7 +127,7 @@ App::App()
 	panel3->style()->set("padding: 11px");
 	panel3->style()->set("flex-direction: row");
 	panel3->style()->set("flex: auto");
-	root_view->add_child(panel3);
+	pRootView->add_child(panel3);
 
 	auto button3 = Theme::create_button();
 	button3->style()->set("height: 40px");
@@ -146,7 +150,7 @@ App::App()
 	panel4->style()->set("padding: 11px");
 	panel4->style()->set("flex-direction: row");
 	panel4->style()->set("flex: auto");
-	root_view->add_child(panel4);
+	pRootView->add_child(panel4);
 
 	button4 = Theme::create_button();
 	button4->style()->set("height: 40px");
@@ -187,4 +191,14 @@ void App::on_button3_down()
 void App::on_button4_down()
 {
 	label4->set_text(button4->pressed() ? "Sticky button is pressed" : "Sticky button is unpressed");
+}
+
+bool App::update()
+{
+	// This needs only if nothing is drawn. Otherwise, use display_window().flip().
+	window->display_window().request_repaint();
+
+	//window->display_window().flip();
+
+	return true;
 }

--- a/Examples/UI/FileDialogs/Sources/app.h
+++ b/Examples/UI/FileDialogs/Sources/app.h
@@ -34,6 +34,7 @@ class App : public clan::Application
 {
 public:
 	App();
+	bool update() override;
 
 	clan::UIThread ui_thread;
 	std::shared_ptr<clan::TopLevelWindow> window;

--- a/Examples/UI/HelloWorld/Sources/helloworld.h
+++ b/Examples/UI/HelloWorld/Sources/helloworld.h
@@ -25,6 +25,7 @@
 **
 **    Magnus Norddahl
 **    Mark Page
+**    Artem Khomenko
 */
 
 #pragma once
@@ -33,10 +34,10 @@ class HelloWorld : public clan::Application
 {
 public:
 	HelloWorld();
+	bool update() override;
 
 	clan::UIThread ui_thread;
 	std::shared_ptr<clan::TopLevelWindow> window;
 	std::shared_ptr<clan::LabelView> label;
 	clan::WindowManager window_manager;
-	clan::SlotContainer slots;
 };

--- a/Examples/UI/MVC/app.cpp
+++ b/Examples/UI/MVC/app.cpp
@@ -16,5 +16,13 @@ App::App()
 	ui_thread = UIThread(resources);
 
 	window_manager.set_exit_on_last_close();
-	window_manager.present_main<MainWindowController>();
+	auto pRootView = window_manager.present_main<MainWindowController>()->root_view();
+
+	// Exit run loop when ESC pressed.
+	pRootView->slots.connect(pRootView->sig_key_press(), [&](clan::KeyEvent &e)
+	{ if (e.key() == clan::Key::escape) RunLoop::exit(); }
+	);
+
+	// Need for receive a keyboard events.
+	pRootView->set_focus();
 }

--- a/Examples/UI/TextureView/Sources/gui.cpp
+++ b/Examples/UI/TextureView/Sources/gui.cpp
@@ -35,8 +35,11 @@ clan::ApplicationInstance<GUI> clanapp;
 
 GUI::GUI()
 {
-	//clan::D3DTarget::set_current();
+#if defined(WIN32) && !defined(__MINGW32__)
+	clan::D3DTarget::set_current();
+#else
 	clan::OpenGLTarget::set_current();
+#endif
 
 	// Set the window
 	clan::DisplayWindowDescription desc;
@@ -60,7 +63,6 @@ GUI::GUI()
 	gui_image = clan::Image(gui_texture, gui_texture.get_size());
 	clan::FrameBuffer gui_framebuffer = clan::FrameBuffer(canvas);
 	gui_framebuffer.attach_color(0, gui_texture);
-	//gui_canvas = clan::Canvas(canvas);//, gui_framebuffer);
 	gui_canvas = clan::Canvas(canvas, gui_framebuffer);
 
 	// Mark this thread as the UI thread
@@ -142,7 +144,6 @@ bool GUI::update()
 
 	canvas.clear(clan::Colorf(0.3f,0.7f,0.2f));
 
-	//ui_window->view_controller()->view->set_needs_layout();
 	//ui_window->set_always_render();
 	ui_window->update();
 	gui_canvas.flush();

--- a/Sources/API/UI/StandardViews/checkbox_view.h
+++ b/Sources/API/UI/StandardViews/checkbox_view.h
@@ -26,7 +26,7 @@
 **    Magnus Norddahl
 **    Harry Storbacka
 **    Mark Page
-**    Artem Khomenko (add label property)
+**    Artem Khomenko (add label property and render_background())
 */
 
 #pragma once
@@ -62,6 +62,11 @@ namespace clan
 
 		/// \brief Func state changed
 		std::function<void()> &func_state_changed();
+
+	protected:
+
+		/// Override - need to clear background under label due to Subpixel font rendering.
+		void render_background(Canvas &canvas) override;
 
 	private:
 		std::shared_ptr<CheckBoxView_Impl> impl;

--- a/Sources/API/UI/StandardViews/label_view.h
+++ b/Sources/API/UI/StandardViews/label_view.h
@@ -80,6 +80,9 @@ namespace clan
 
 		void layout_children(Canvas &canvas) override;
 
+		/// Update the font in according to style.
+		void reset_font();
+
 	protected:
 		void render_content(Canvas &canvas) override;
 		float calculate_preferred_width(Canvas &canvas) override;

--- a/Sources/API/UI/View/view.h
+++ b/Sources/API/UI/View/view.h
@@ -24,6 +24,7 @@
 **  File Author(s):
 **
 **    Magnus Norddahl
+**    Artem Khomenko (Direct redraw changed state of View, without redraw the entire window).
 */
 
 #pragma once
@@ -79,7 +80,7 @@ namespace clan
 		/// Set or clear style state
 		void set_state(const std::string &name, bool value);
 
-		/// Sets the state for this view and all siblings recursively, until a manually set state of the same name is found
+		/// Sets the state for this view and all children recursively, until a manually set state of the same name is found
 		void set_state_cascade(const std::string &name, bool value);
 
 		/// Slot container helping with automatic disconnection of connected slots when the view is destroyed
@@ -303,9 +304,18 @@ namespace clan
 		/// Dispatch event to signals listening for events
 		static void dispatch_event(View *target, EventUI *e, bool no_propagation = false);
 
+		/// Render view and its children directly, without re-layout.
+		void draw_without_layout();
+
 	protected:
 		/// Renders the content of a view
 		virtual void render_content(Canvas &canvas) { }
+
+		/// Renders the border of a view
+		virtual void render_border(Canvas &canvas);
+
+		/// Renders the background of a view
+		virtual void render_background(Canvas &canvas);
 
 		/// Child view was added to this view
 		virtual void child_added(const std::shared_ptr<View> &view) { }

--- a/Sources/UI/StandardViews/ButtonView/button_view_impl.cpp
+++ b/Sources/UI/StandardViews/ButtonView/button_view_impl.cpp
@@ -31,34 +31,24 @@
 #include "UI/precomp.h"
 #include "API/UI/StandardViews/button_view.h"
 #include "API/UI/StandardViews/image_view.h"
-#include "button_view_impl.h"
 #include "API/UI/Events/pointer_event.h"
+#include "button_view_impl.h"
 
 namespace clan
 {
 
 	void ButtonViewImpl::update_state()
 	{
-		bool target_hot = false;
-		bool target_disabled = false;
-		bool target_pressed = false;
+		// Update CSS.
+		button->set_state_cascade("hot", _state_hot);
+		button->set_state_cascade("pressed", _state_pressed);
+		button->set_state_cascade("disabled", _state_disabled);
+		
+		// Update the font in accordance with the state.
+		label->reset_font();
 
-		if (_state_disabled)
-		{
-			target_disabled = true;
-		}
-		else if (_state_pressed)
-		{
-			target_pressed = true;
-		}
-		else if (_state_hot)
-		{
-			target_hot = true;
-		}
-
-		button->set_state_cascade("hot", target_hot);
-		button->set_state_cascade("pressed", target_pressed);
-		button->set_state_cascade("disabled", target_disabled);
+		// Fast draw the button.
+		button->draw_without_layout();
 	}
 
 	void ButtonViewImpl::on_pointer_press(PointerEvent &e)

--- a/Sources/UI/StandardViews/CheckBoxView/checkbox_view.cpp
+++ b/Sources/UI/StandardViews/CheckBoxView/checkbox_view.cpp
@@ -26,13 +26,14 @@
 **    Harry Storbacka
 **    Magnus Norddahl
 **    Mark Page
-**    Artem Khomenko (add label property)
+**    Artem Khomenko (add label property and render_background())
 */
 
 #include "UI/precomp.h"
 #include "API/UI/StandardViews/checkbox_view.h"
 #include "API/UI/Style/style_property_parser.h"
 #include "API/Display/2D/path.h"
+#include "API/Display/2D/canvas.h"
 #include "API/Display/System/timer.h"
 #include "API/Display/2D/brush.h"
 #include "API/UI/Events/pointer_event.h"
@@ -101,6 +102,30 @@ namespace clan
 	std::function<void()> &CheckBoxView::func_state_changed()
 	{
 		return impl->_func_state_changed;
+	}
+
+	void CheckBoxView::render_background(Canvas &canvas)
+	{
+		// If someone wants to make a transparent background under the label, he needs to call parent.
+		// But now simple fill background.
+
+		// Find background color
+		Colorf backColor = Colorf::transparent;
+		View *ptr = this;
+		while (ptr) {
+			const StyleGetValue value = ptr->style_cascade().cascade_value("background-color");
+			if (!value.is_undefined()) {
+				backColor = value.color();
+				break;
+			}
+			ptr = ptr->parent();
+		}
+
+		// Clear backgroud
+		canvas.fill_rect(geometry().content_box(), backColor);
+
+		// Call the predecessor.
+		View::render_background(canvas);
 	}
 
 }

--- a/Sources/UI/StandardViews/CheckBoxView/checkbox_view_impl.cpp
+++ b/Sources/UI/StandardViews/CheckBoxView/checkbox_view_impl.cpp
@@ -99,6 +99,9 @@ namespace clan
 		checkbox->set_state_cascade("unchecked_hot", target_unchecked_hot);
 		checkbox->set_state_cascade("unchecked_pressed", target_unchecked_pressed);
 		checkbox->set_state_cascade("unchecked_disabled", target_unchecked_disabled);
+
+		// Fast draw the checkbox.
+		checkbox->draw_without_layout();
 	}
 
 	void CheckBoxView_Impl::on_pointer_press(PointerEvent &e)

--- a/Sources/UI/TopLevel/TextureWindow/texture_window_impl.cpp
+++ b/Sources/UI/TopLevel/TextureWindow/texture_window_impl.cpp
@@ -150,6 +150,8 @@ namespace clan
 				hot_view->update_cursor(display_window);
 		}
 
+		// Status changes are made fast redraw controls and we need to show it.
+		needs_render = true;
 	}
 
 	void TextureWindow_Impl::release_capture()

--- a/Sources/UI/View/view_impl.h
+++ b/Sources/UI/View/view_impl.h
@@ -83,7 +83,7 @@ namespace clan
 		View *find_next_with_tab_index(unsigned int tab_index, const ViewImpl *search_from = nullptr, bool also_search_ancestors = true) const;
 		View *find_prev_with_tab_index(unsigned int tab_index, const ViewImpl *search_from = nullptr, bool also_search_ancestors = true) const;
 
-		void set_state_cascade_siblings(const std::string &name, bool value);
+		void set_state_cascade_children(const std::string &name, bool value);
 
 		void inverse_bubble(EventUI *e);
 


### PR DESCRIPTION
* The old scheme of work - when the state changes (hot/unhot, pressed/checked and so on), next was call `set_needs_layout();`, which led to a recalculation of all sizes and call `Invalidate` for the whole window at the end.
* The new scheme of work - when the state changes there is redrawn once - set `clip_rect`, render parent for update the background under the changed item, then draw the element itself and its children.

The changes made suitable use of UI controls in the applications running on the `clan :: Application :: update()`, because now they do not cause repeated redrawing the entire window.

Before making changes on a laptop with a built-in videocard, the window with multiple controls (`ButtonView`, `CheckBoxView`, `LabelView`) at rest FPS was about 800. After start move the mouse through all the controls, FPS sink 100 times - less than 10 frames per second. After making changes there no visible reduction the FPS.

Also small changes in the examples are done.