### PR TITLE
CheckBoxView small fixes

### DIFF
--- a/Examples/ThemeAero/Sources/theme.cpp
+++ b/Examples/ThemeAero/Sources/theme.cpp
@@ -133,6 +133,7 @@ std::shared_ptr<clan::CheckBoxView> Theme::create_checkbox()
 
 	checkbox->style()->set("background-repeat:no-repeat;");
 	checkbox->style()->set("background-attachment:scroll;");
+	checkbox->style()->set("background-position: center left;");
 	checkbox->style()->set("background-image:url('Resources/checkbox_unchecked_normal.png');");
 	checkbox->style("unchecked_hot")->set("background-image:url('Resources/checkbox_unchecked_hot.png');");
 	checkbox->style("unchecked_pressed")->set("background-image:url('Resources/checkbox_unchecked_pressed.png');");
@@ -141,9 +142,8 @@ std::shared_ptr<clan::CheckBoxView> Theme::create_checkbox()
 	checkbox->style("checked_hot")->set("background-image:url('Resources/checkbox_checked_hot.png');");
 	checkbox->style("checked_pressed")->set("background-image:url('Resources/checkbox_checked_pressed.png');");
 	checkbox->style("checked_disabled")->set("background-image:url('Resources/checkbox_checked_disabled.png');");
-	checkbox->label()->style()->set("font: 13px 'Segoe UI'; padding: -3px 30px; color: black;");
+	checkbox->label()->style()->set("font: 13px 'Segoe UI'; padding: 0px 30px; color: black;");
 	checkbox->label()->style("disabled")->set("color: rgb(128,128,128);");
-	checkbox->label()->style("pressed")->set("font-weight: bold;");
 	checkbox->label()->set_text_alignment(TextAlignment::left);
 	return checkbox;
 }

--- a/Sources/UI/StandardViews/CheckBoxView/checkbox_view_impl.cpp
+++ b/Sources/UI/StandardViews/CheckBoxView/checkbox_view_impl.cpp
@@ -99,6 +99,10 @@ namespace clan
 		checkbox->set_state_cascade("unchecked_hot", target_unchecked_hot);
 		checkbox->set_state_cascade("unchecked_pressed", target_unchecked_pressed);
 		checkbox->set_state_cascade("unchecked_disabled", target_unchecked_disabled);
+		label->set_state_cascade("disabled", _state_disabled);
+
+		// Update the font in accordance with the state.
+		label->reset_font();
 
 		// Fast draw the checkbox.
 		checkbox->draw_without_layout();

--- a/Sources/UI/Style/style_background_renderer.cpp
+++ b/Sources/UI/Style/style_background_renderer.cpp
@@ -358,7 +358,7 @@ namespace clan
 		else
 		{
 			y = origin_box.top;
-			StyleGetValue pos_y = get_layer_position_x(index);
+			StyleGetValue pos_y = get_layer_position_y(index);
 			if (pos_y.is_keyword("top"))
 				y = origin_box.top;
 			else if (pos_y.is_keyword("center"))


### PR DESCRIPTION
1. When state changes, label style changes too
2. Box for check now are at center left, not in top left.