### PR TITLE
UI bug fixes and improvements

### DIFF
--- a/Examples/ThemeAero/Sources/theme.cpp
+++ b/Examples/ThemeAero/Sources/theme.cpp
@@ -234,6 +234,8 @@ std::shared_ptr<clan::ListBoxView> Theme::create_listbox()
 {
 	auto listbox = std::make_shared<clan::ListBoxView>();
 	listbox->style()->set("margin: 7px 0; border: 1px solid black; padding: 5px; background: #f0f0f0");
+	initialize_scrollbar(listbox->scrollbar_x_view(), true);
+	initialize_scrollbar(listbox->scrollbar_y_view(), false);
 	return listbox;
 }
 

--- a/Examples/UI/HelloWorld/Sources/helloworld.cpp
+++ b/Examples/UI/HelloWorld/Sources/helloworld.cpp
@@ -101,7 +101,7 @@ HelloWorld::HelloWorld()
 
 	auto scrollarea = std::make_shared<ScrollView>();
 	scrollarea->style()->set("margin: 5px 0; border: 1px solid black; padding: 5px 0px 5px 5px;");
-	scrollarea->content_view()->style()->set("flex-direction: column;");
+	scrollarea->content_view()->style()->set("flex-direction: column; background: white;");
 	Theme::initialize_scrollbar(scrollarea->scrollbar_y_view(), false);
 	scrollarea->scrollbar_y_view()->style()->set("padding: 0 0 0 3px; background: white;");
 	body->add_child(scrollarea);
@@ -162,18 +162,13 @@ HelloWorld::HelloWorld()
 	gradient_box->style()->set("box-shadow: 7px 7px 7px rgba(0,0,0,0.2)");
 	scrollarea->content_view()->add_child(gradient_box);
 	
-	auto listbox = std::make_shared<ListBoxView>();
+	auto listbox = Theme::create_listbox();
 	listbox->style()->set("flex: none; height: 60px; margin: 7px 0; border: 1px solid black; padding: 5px; background: #f0f0f0");
 	listbox->set_items<std::string>(
 		{ "Item 1", "Item 2", "Item 3", "Item 4", "Item 5", "More items", "Even more items!!", "No more items!!!!!" },
 		[](const std::string &s) -> std::shared_ptr<View>
 		{
-			auto item = std::make_shared<LabelView>();
-			item->style()->set("font: 13px/17px 'Segoe UI'; color: black; margin: 1px 0; padding: 0 2px");
-			item->style("selected")->set("background: #7777f0; color: white");
-			item->style("hot")->set("background: #ccccf0; color: black");
-
-			item->set_text(s);
+			auto item = Theme::create_listbox_label(s);
 			return item;
 		});
 	scrollarea->content_view()->add_child(listbox);
@@ -206,6 +201,7 @@ HelloWorld::HelloWorld()
 	checkbox->label()->set_text("Checkbox");
 	scrollarea->content_view()->add_child(checkbox);
 
+	// Hint - parent of the radiobutton must have an opaque background due to sub-pixel rendering effect.
 	for (int cnt = 0; cnt < 3; cnt++)
 	{
 		auto radio = Theme::create_radiobutton();
@@ -281,10 +277,7 @@ HelloWorld::HelloWorld()
 
 bool HelloWorld::update()
 {
-	// This needs only if nothing is drawn. Otherwise, use display_window().flip().
-	window->display_window().request_repaint();
-
-	//window->display_window().flip();
+	window->display_window().flip();
 
 	return true;
 }

--- a/Sources/API/Core/Math/rect.h
+++ b/Sources/API/Core/Math/rect.h
@@ -223,6 +223,16 @@ namespace clan
 			return *this;
 		}
 
+		/// \brief Sets the bottom-right point of the rectangle.
+		///
+		/// \return reference to this object
+		Rectx<Type> &set_bottom_right(const Vec2<Type>& p)
+		{
+			right = p.x;
+			bottom = p.y;
+			return *this;
+		}
+
 		/// \brief Sets the width of the rectangle.
 		///
 		/// \return reference to this object

--- a/Sources/API/UI/StandardViews/listbox_view.h
+++ b/Sources/API/UI/StandardViews/listbox_view.h
@@ -24,6 +24,7 @@
 **  File Author(s):
 **
 **    Magnus Norddahl
+**    Artem Khomenko
 */
 
 #pragma once
@@ -60,7 +61,12 @@ namespace clan
 
 		std::function<void()> &func_selection_changed();
 
+		void layout_children(Canvas &canvas) override;
+
 	private:
 		std::unique_ptr<ListBoxViewImpl> impl;
+
+		// Sets in set_selected_item() for scroll to selected in layout_children().
+		bool needScrollToSelected = false;
 	};
 }

--- a/Sources/API/UI/StandardViews/scrollbar_view.h
+++ b/Sources/API/UI/StandardViews/scrollbar_view.h
@@ -24,6 +24,7 @@
 **  File Author(s):
 **
 **    Magnus Norddahl
+**    Artem Khomenko
 */
 
 #pragma once
@@ -62,6 +63,9 @@ namespace clan
 		void set_line_step(double value);
 		void set_page_step(double value);
 
+		/// When true the position can be only in integer amount of line_step.
+		void set_lock_to_line(bool lock);
+
 		double min_position() const;
 		double max_position() const;
 		double position() const;
@@ -75,13 +79,7 @@ namespace clan
 
 		void layout_children(Canvas &canvas) override;
 
-		/// Fast redraw without layout.
-		void redraw_without_layout();
-
 	private:
 		std::shared_ptr<ScrollBarViewImpl> impl;
-
-		// Without inherited View::layout_children()
-		void update_style_pos();
 	};
 }

--- a/Sources/API/UI/StandardViews/slider_view.h
+++ b/Sources/API/UI/StandardViews/slider_view.h
@@ -25,6 +25,7 @@
 **
 **    Magnus Norddahl
 **    Mark Page
+**    Artem Khomenko
 */
 
 #pragma once
@@ -63,6 +64,8 @@ namespace clan
 
 		void set_tick_count(int tick_count);
 		void set_page_step(int page_step);
+
+		/// When true the position can be only in integer amount of tick_count.
 		void set_lock_to_ticks(bool lock);
 
 		std::function<void()> &func_value_changed();

--- a/Sources/API/UI/View/view.h
+++ b/Sources/API/UI/View/view.h
@@ -295,8 +295,8 @@ namespace clan
 		/// Map from screen to local content coordinates
 		Pointf from_screen_pos(const Pointf &pos);
 
-		/// Map from local content to root content coordinates
-		Pointf to_root_pos(const Pointf &pos);
+		/// Map from local content to root content or margin (plus content, padding, border and margin) coordinates.
+		Pointf to_root_pos(const Pointf &pos, bool relative_to_margin = false);
 
 		/// Map from root content to local content coordinates
 		Pointf from_root_pos(const Pointf &pos);

--- a/Sources/UI/StandardViews/ListBoxView/listbox_view_impl.cpp
+++ b/Sources/UI/StandardViews/ListBoxView/listbox_view_impl.cpp
@@ -25,6 +25,7 @@
 **
 **    Magnus Norddahl
 **    Mark Page
+**    Artem Khomenko
 */
 
 #include "UI/precomp.h"
@@ -95,12 +96,12 @@ namespace clan
 			index++;
 		}
 		return -1;
-
 	}
 
 	void ListBoxViewImpl::set_hot_item(int index)
 	{
-		if ((index == hot_item) || (index == selected_item))		// Selected item state has priority
+		// Selected item state has priority.
+		if (index == hot_item || index == selected_item && index != -1)
 			return;
 
 		if (index < -1 || index >= (int) listbox->content_view()->children().size())
@@ -116,6 +117,12 @@ namespace clan
 		}
 
 		hot_item = index;
+
+		// Draw changes - try to call for child to render its parent, i.e. slider.
+		if (index != -1)
+			listbox->children().front()->draw_without_layout();
+		else
+			listbox->draw_without_layout();
 	}
 
 	void ListBoxViewImpl::on_pointer_enter(PointerEvent &e)

--- a/Sources/UI/StandardViews/RadioButtonView/radiobutton_view_impl.cpp
+++ b/Sources/UI/StandardViews/RadioButtonView/radiobutton_view_impl.cpp
@@ -99,6 +99,9 @@ namespace clan
 		radio->set_state_cascade("unchecked_hot", target_unchecked_hot);
 		radio->set_state_cascade("unchecked_pressed", target_unchecked_pressed);
 		radio->set_state_cascade("unchecked_disabled", target_unchecked_disabled);
+
+		// Draw changes.
+		radio->draw_without_layout();
 	}
 
 	void RadioButtonView_Impl::on_pointer_press(PointerEvent &e)

--- a/Sources/UI/StandardViews/ScrollBarView/scrollbar_view.cpp
+++ b/Sources/UI/StandardViews/ScrollBarView/scrollbar_view.cpp
@@ -276,11 +276,7 @@ namespace clan
 	void ScrollBarView::layout_children(Canvas &canvas)
 	{
 		View::layout_children(canvas);
-		update_style_pos();
-	}
 
-	void ScrollBarView::update_style_pos()
-	{
 		// Update the CSS properties.
 		auto track_geometry = impl->track->geometry();
 
@@ -303,26 +299,14 @@ namespace clan
 		}
 	}
 
-	void ScrollBarView::redraw_without_layout()
-	{
-		// Fast redraw without layout.
-
-		// Update CSS of thumb.
-		update_style_pos();
-
-		// Current box for thumb relative to track.
-		Rectf box = impl->track->geometry().content_box();
-
-		// Update geometry from CSS.
-		impl->thumb->set_geometry(ViewGeometry::from_margin_box(impl->thumb->style_cascade(), box));
-
-		// Draw the track and it will be draw the its parent.
-		impl->track->draw_without_layout();
-	}
-
 	Signal<void()> &ScrollBarView::sig_scroll()
 	{
 		return impl->sig_scroll;
+	}
+
+	void ScrollBarView::set_lock_to_line(bool lock)
+	{
+		impl->_lock_to_line = lock;
 	}
 
 }

--- a/Sources/UI/StandardViews/ScrollBarView/scrollbar_view_impl.h
+++ b/Sources/UI/StandardViews/ScrollBarView/scrollbar_view_impl.h
@@ -132,6 +132,7 @@ namespace clan
 		double max_pos = 100.0;
 		double pos = 0.0;
 		double line_step = 1.0;
+		bool _lock_to_line = false;
 		double page_step = 25.0;
 		double timer_step_size = 0.0;
 		double timer_target_position = 0.0;

--- a/Sources/UI/StandardViews/SliderView/slider_view_impl.cpp
+++ b/Sources/UI/StandardViews/SliderView/slider_view_impl.cpp
@@ -25,6 +25,7 @@
 **
 **    Magnus Norddahl
 **    Mark Page
+**    Artem Khomenko
 */
 
 #include "UI/precomp.h"
@@ -35,10 +36,17 @@
 #include "API/Display/2D/brush.h"
 #include "API/UI/Events/pointer_event.h"
 #include <algorithm>
+#include "API/UI/TopLevel/view_tree.h"
+#include "API/Display/Window/display_window.h"
+#include "API/Display/Window/input_event.h"
 #include "slider_view_impl.h"
 
 namespace clan
 {
+	// Delays for timer
+	const int cLongDelay = 300;
+	const int cShortDelay = 30;
+
 	void SliderViewImpl::update_state()
 	{
 		bool target_hot = false;
@@ -61,6 +69,9 @@ namespace clan
 		slider->set_state_cascade("hot", target_hot);
 		slider->set_state_cascade("pressed", target_pressed);
 		slider->set_state_cascade("disabled", target_disabled);
+
+		// Draw changes.
+		slider->draw_without_layout();
 	}
 
 	void SliderViewImpl::update_pos(SliderView *view, int new_pos, int new_min, int new_max)
@@ -71,6 +82,8 @@ namespace clan
 			_min_position = new_min;
 			_max_position = new_max;
 			_position = new_pos;
+
+			// Update the view.
 			view->set_needs_layout();
 		}
 	}
@@ -89,7 +102,6 @@ namespace clan
 
 	void SliderViewImpl::on_activated(ActivationChangeEvent &e)
 	{
-
 	}
 
 	void SliderViewImpl::on_deactivated(ActivationChangeEvent &e)
@@ -105,23 +117,21 @@ namespace clan
 	{
 		if (_state_disabled || e.button() != PointerButton::left)
 			return;
-		if (e.target() == thumb)	// Thumb control handled elsewhere
-			return;
 
 		float mouse_pos;
-		Rectf thumb_geometry(thumb->geometry().content_box());
+		const ViewGeometry &thumb_geometry(thumb->geometry());
 		float thumb_position;
 		if (slider->horizontal())
 		{
 			mouse_pos = e.pos(track.get()).x;
-			thumb_position = thumb_geometry.left + thumb_geometry.get_width() / 2.0f;
-			timer_target_position = _min_position + mouse_pos * ((_max_position - _min_position)) / (track->geometry().content_box().get_width());
+			thumb_position = thumb_geometry.content_x + thumb_geometry.content_width * 0.5f;
+			timer_target_position = _min_position + mouse_pos * thumb_units_per_pixel();
 		}
 		else
 		{
 			mouse_pos = e.pos(track.get()).y;
-			thumb_position = thumb_geometry.top + thumb_geometry.get_height() / 2.0f;
-			timer_target_position = _min_position + mouse_pos * ((_max_position - _min_position)) / (track->geometry().content_box().get_height());
+			thumb_position = thumb_geometry.content_y + thumb_geometry.content_height * 0.5f;
+			timer_target_position = _min_position + mouse_pos * thumb_units_per_pixel();
 		}
 
 		if (mouse_pos < thumb_position)
@@ -135,6 +145,8 @@ namespace clan
 			timer_step_size = _page_step;
 		}
 
+		// For scroll timer - between first and second there is need a big delay, then small.
+		isFirstTimerExpired = true;
 		scroll_timer_expired();
 	}
 
@@ -144,6 +156,41 @@ namespace clan
 			return;
 		mouse_down_mode = mouse_down_none;
 		scroll_timer.stop();
+
+		// Mouse position relative to track.
+		Pointf mouse_pos = e.pos(slider->track());
+
+		// Thumb position relative to track.
+		Rectf thumb_geometry(thumb->geometry().content_box());
+
+		// Check and set hot state by long and winding road - need to reach TopLevelWindow_Impl::dispatch_hot_event().
+		auto tree = slider->view_tree();
+		DisplayWindow *pDispWindow = &tree->display_window();
+		if (pDispWindow) {
+			InputDevice *pInputDevice = &pDispWindow->get_mouse();
+			if (pInputDevice) {
+
+				// Root view.
+				auto rootView = tree->root_view();
+
+				// Mouse position relative to root.
+				Pointf mouse_pos = e.pos(rootView);
+
+				// Change relative to screen.
+				mouse_pos = rootView->to_screen_pos(mouse_pos);
+
+				// Change relative to client.
+				mouse_pos = pDispWindow->screen_to_client(mouse_pos);
+
+				// Prepare event to be emitted:
+				InputEvent moveEvent;
+				moveEvent.type = InputEvent::pointer_moved;
+				moveEvent.mouse_pos = mouse_pos;
+
+				// Send message.
+				pInputDevice->sig_pointer_move()(moveEvent);
+			}
+		}
 	}
 
 	void SliderViewImpl::on_pointer_thumb_press(PointerEvent &e)
@@ -156,6 +203,8 @@ namespace clan
 		mouse_down_mode = mouse_down_thumb_drag;
 		thumb_move_start_position = _position;
 		mouse_drag_start_pos = e.pos(track.get());
+
+		e.stop_propagation(); // prevent track press reacting to this event
 	}
 
 	void SliderViewImpl::on_pointer_thumb_release(PointerEvent &e)
@@ -165,55 +214,47 @@ namespace clan
 		_state_pressed = false;
 		update_state();
 		mouse_down_mode = mouse_down_none;
-		scroll_timer.stop();
+
+		e.stop_propagation(); // prevent track press reacting to this event
 	}
 
 	void SliderViewImpl::on_pointer_move(PointerEvent &e)
 	{
-		if (_state_disabled)
+		if (_state_disabled || mouse_down_mode != mouse_down_thumb_drag)
 			return;
-		if (mouse_down_mode != mouse_down_thumb_drag)
-		{
-			return;
-		}
 
 		Pointf mouse_pos(e.pos(track.get()));
-		Rectf track_geometry(track->geometry().content_box());
+		const ViewGeometry &track_geometry(track->geometry());
 
 		int last_position = _position;
 
-		if (mouse_pos.x < -100 || mouse_pos.x > track_geometry.get_width() + 100 || mouse_pos.y < -100 || mouse_pos.y > track_geometry.get_height() + 100)
+		if (mouse_pos.x < -100 || mouse_pos.x > track_geometry.content_width + 100 || mouse_pos.y < -100 || mouse_pos.y > track_geometry.content_height + 100)
 		{
+			// If the mouse strayed very far away, back to the starting position the thumb.
 			_position = thumb_move_start_position;
 		}
 		else
 		{
-			if (slider->horizontal())
-			{
-				int delta = (mouse_pos.x - mouse_drag_start_pos.x);
-				_position = thumb_move_start_position + (delta * (_max_position - _min_position)) / (track->geometry().content_box().get_width());
-			}
-			else
-			{
-				int delta = (mouse_pos.y - mouse_drag_start_pos.y);
-				_position = thumb_move_start_position + (delta * (_max_position - _min_position)) / (track->geometry().content_box().get_height());
-			}
+			int delta = slider->horizontal() ? mouse_pos.x - mouse_drag_start_pos.x : mouse_pos.y - mouse_drag_start_pos.y;
+			_position = thumb_move_start_position + delta * thumb_units_per_pixel();
 		}
+
+		// Set position to near integer in _lock_to_ticks if needs.
+		if (_lock_to_ticks)
+			_position = (int)roundf((float)_position / _tick_count) * _tick_count;
+
 		if (_position > _max_position)
 			_position = _max_position;
-		if (_position < _min_position)
+		else if (_position < _min_position)
 			_position = _min_position;
-
-		if (_lock_to_ticks)
-		{
-			int remainder = (_position - _min_position) % _tick_count;
-			_position = _position - remainder;
-		}
 
 		if (last_position != _position)
 		{
+			// Notify the user.
 			if (_func_value_changed)
 				_func_value_changed();
+
+			// Update the view.
 			slider->set_needs_layout();
 		}
 	}
@@ -228,30 +269,29 @@ namespace clan
 		int last_position = _position;
 		_position += timer_step_size;
 
-		if (mouse_down_mode == mouse_down_track_decr)
-		{
-			if (_position < timer_target_position)
-				_position = timer_target_position;
-		}
-		if (mouse_down_mode == mouse_down_track_incr)
-		{
-			if (_position > timer_target_position)
-				_position = timer_target_position;
-		}
-
-		if (_position > _max_position)
-			_position = _max_position;
 		if (_position < _min_position)
 			_position = _min_position;
+		else if (_position > _max_position)
+			_position = _max_position;
 
 		if (last_position != _position)
 		{
+			// Notify the user.
 			if (_func_value_changed)
 				_func_value_changed();
+
+			// Update the view.
 			slider->set_needs_layout();
 		}
-		scroll_timer.start(100, false);
 
+		// Run timer again only if the goal is not reached.
+		if (mouse_down_mode == mouse_down_track_decr && _position > timer_target_position
+			|| mouse_down_mode == mouse_down_track_incr && _position + _page_step < timer_target_position
+			)
+			scroll_timer.start(isFirstTimerExpired ? cLongDelay : cShortDelay, false);
+
+		// Switch to a short delay.
+		isFirstTimerExpired = false;
 	}
 
 }

--- a/Sources/UI/StandardViews/SliderView/slider_view_impl.h
+++ b/Sources/UI/StandardViews/SliderView/slider_view_impl.h
@@ -48,6 +48,36 @@ namespace clan
 
 		void scroll_timer_expired();
 
+		// Pixel length of the entire scrollbar track
+		int track_length() const
+		{
+			auto track_geometry = track->geometry();
+			return slider->vertical() ? track_geometry.content_box().get_height() : track_geometry.content_box().get_width();
+		}
+
+		// Pixel length of thumb
+		double thumb_length() const
+		{
+			return _vertical ? thumb->geometry().content_height : thumb->geometry().content_width;
+		}
+
+		// Pixel position of thumb
+		int thumb_pos() const
+		{
+			if (_min_position == _max_position)
+				return 0;
+			double t = (_position - _min_position) / double(_max_position - _min_position);
+			return int(round(t * (track_length() - thumb_length())));
+		}
+
+		// How many units to move per pixel when dragging the thumb
+		double thumb_units_per_pixel() const
+		{
+			double available_units = _max_position - _min_position;
+			double available_pixels = track_length() - thumb_length();
+			return available_pixels != 0.0 ? available_units / available_pixels : 0.0;
+		}
+
 		enum MouseDownMode
 		{
 			mouse_down_none,
@@ -83,6 +113,9 @@ namespace clan
 		void update_pos(SliderView *view, int new_pos, int new_min, int new_max);
 		void update_state();
 
+	private:
+		// For scroll timer - between first and second need a big delay, then the small one.
+		bool isFirstTimerExpired = true;
 	};
 
 }

--- a/Sources/UI/StandardViews/scroll_view.cpp
+++ b/Sources/UI/StandardViews/scroll_view.cpp
@@ -80,6 +80,8 @@ namespace clan
 		impl->scroll_y->set_hidden();
 		impl->scroll_x->set_horizontal();
 		impl->scroll_y->set_vertical();
+		impl->scroll_x->set_lock_to_line(true);
+		impl->scroll_y->set_lock_to_line(true);
 
 		impl->content_container->style()->set("flex: 1 1 auto");
 
@@ -207,13 +209,16 @@ namespace clan
 		
 		if (x_scroll_needed)
 		{
-			impl->scroll_x->set_max_position(std::max(content_width - content_view_width, 0.0f));
+			// Max position is that does not fit on the view.
+			impl->scroll_x->set_max_position(round(std::max(content_width - content_view_width, 0.0f)));
+
+			// Page size is equal size of the view.
 			impl->scroll_x->set_page_step(content_view_width);
 		}
 		
 		if (y_scroll_needed)
 		{
-			impl->scroll_y->set_max_position(std::max(content_height - content_view_height, 0.0f));
+			impl->scroll_y->set_max_position(round(std::max(content_height - content_view_height, 0.0f)));
 			impl->scroll_y->set_page_step(content_view_height);
 		}
 		


### PR DESCRIPTION
Bug fixes
* SliderView scroll to the right of the maximum
* Add property `lock_to_line` to the ScrollbarView and remove unwanted effect from sub-pixel renderind in ScrollView when position is not integral.
* Improved off the hot state on release LBM when scroll thumb occured.
* Fix the bug with `draw_without_layout()` when root has padding.
* Fix the bug with `draw_without_layout()` in the ScrollView.

Improvements
* Remove `redraw_without_layout` for `ScrollBarView` due to call Invalidate in real applications as the reactions to the scroll.
* Scroll to selected item in `ListboxView`.
* Improvement behaviour in `SliderView` when dragging thumb.
* `SliderView` make hot after release LBM
* `SliderView` traditional delay.
* `SliderView` now DoubleClick as SingleClick.
* `SliderView` size of thumb is determined by the size of `SliderView`.
* Changes in HelloWorld example.