### PR TITLE
Corrects compilation error C3848 in VS2015

### DIFF
--- a/Sources/D3D/sampler_state.h
+++ b/Sources/D3D/sampler_state.h
@@ -82,7 +82,7 @@ private:
 
 	struct D3D11SamplerDescLess
 	{
-		bool operator()(const D3D11_SAMPLER_DESC &a, const D3D11_SAMPLER_DESC &b)
+		bool operator()(const D3D11_SAMPLER_DESC &a, const D3D11_SAMPLER_DESC &b) const
 		{
 			return memcmp(&a, &b, sizeof(D3D11_SAMPLER_DESC)) < 0;
 		}


### PR DESCRIPTION
Adds a const modifier to operator () overloading to correct compilation error C3848 in VS2015.