### PR TITLE
Bugfix for UI

### DIFF
--- a/Sources/UI/View/view.cpp
+++ b/Sources/UI/View/view.cpp
@@ -733,7 +733,7 @@ namespace clan
 
 		// Ask the parent for redraw and then it redraws us.
 		View *prnt = parent();
-		Canvas canv; // empty canvas
+		Canvas canv = canvas();
 
 		// Drawing area - start from our margin_box.
 		Rectf clipBox(geom.margin_box());


### PR DESCRIPTION
Using empty canvas (with default constructor instead _canvas()_ ) in void View::draw_without_layout() raise a runtime error.
It can be tested with HelloWorld example.