### PR TITLE
Improving performance UI

### DIFF
--- a/Sources/API/UI/StandardViews/text_field_view.h
+++ b/Sources/API/UI/StandardViews/text_field_view.h
@@ -97,7 +97,11 @@ namespace clan
 		Signal<void()> &sig_selection_changed();
 		Signal<void()> &sig_enter_pressed();
 
+		/// Update yourself with draw_without_layout() and with delay to prevent too frequent calls.
+		void needs_render_delayed();
+
 	protected:
+
 		void render_content(Canvas &canvas) override;
 		float calculate_preferred_width(Canvas &canvas) override;
 		float calculate_preferred_height(Canvas &canvas, float width) override;

--- a/Sources/UI/StandardViews/TextFieldView/text_field_view_impl.h
+++ b/Sources/UI/StandardViews/TextFieldView/text_field_view_impl.h
@@ -154,6 +154,15 @@ namespace clan
 		bool ignore_mouse_events = false;
 		bool mouse_selecting = false;
 
+		/// Timer for render delay
+		Timer render_timer;
+
+		/// Set to true in needs_render_delayed() and set false in delay_func().
+		bool is_delayed = false;
+
+		/// Set to true in needs_render_delayed() if is_delayed not yet false.
+		bool is_need_render_after_timeout = false;
+
 		struct UndoInfo
 		{
 			std::string text;

--- a/Sources/UI/View/view.cpp
+++ b/Sources/UI/View/view.cpp
@@ -733,7 +733,7 @@ namespace clan
 
 		// Ask the parent for redraw and then it redraws us.
 		View *prnt = parent();
-		Canvas canv; // empty canvas
+		Canvas canv = canvas();
 
 		// Drawing area - start from our margin_box.
 		Rectf clipBox(geom.margin_box());


### PR DESCRIPTION
Change state of TextView, include cursor blinks, now do not update the whole window.

It can be checked at HelloWorld example. In old version click on TextView, then press and hold keyboard left button. Load of one CPU core will be very high.

In new version there is all more smoothly.