### PR TITLE
Use pkg-config to find freetype.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -307,7 +307,7 @@ echo ""
 if test "$enable_clanDisplay" != "no"; then
 	echo "Checking for clanDisplay stuff"
 	echo "=============================="
-	CLANLIB_CHECK_LIB(ttf, [`cat $srcdir/Setup/Unix/Tests/ttf.cpp`], clanDisplay, [ *** Cannot find ttf (freetype) (See http://freetype.sourceforge.net )  (Try libfreetype6-dev or better) ], [`freetype-config --libs` ], [ `freetype-config --cflags`])
+	CLANLIB_CHECK_LIB(ttf, [`cat $srcdir/Setup/Unix/Tests/ttf.cpp`], clanDisplay, [ *** Cannot find ttf (freetype) (See http://freetype.sourceforge.net )  (Try libfreetype6-dev or better) ], [`pkg-config --libs freetype2` ], [ `pkg-config --cflags freetype2`])
 
 	dnl  Optional linux/joystick.h
 	AC_CHECK_HEADERS(linux/joystick.h, has_linux_joystick=yes)


### PR DESCRIPTION
As of freetype-2.9.1 the freetype-config file no longer gets installed
by default.

See also [Make installation of `freetype-config' optional](http://git.savannah.gnu.org/cgit/freetype/freetype2.git/commit/?id=a7833f26c4ac45cafe1dffdcd7f7dcfd6493161c) commit by freetype upstream. 