### PR TITLE
Remake IODevice from int to size_t

### DIFF
--- a/Sources/API/Core/IOData/iodevice.h
+++ b/Sources/API/Core/IOData/iodevice.h
@@ -79,14 +79,14 @@ namespace clan
 		void throw_if_null() const;
 
 		/// \brief Returns the size of data stream.
-		/** <p>Returns -1 if the size is unknown.</p>
-			\return The size (-1 if size is unknown)*/
-		int get_size() const;
+		/** <p>Returns SIZE_MAX if the size is unknown.</p>
+			\return The size (SIZE_MAX if size is unknown)*/
+		size_t get_size() const;
 
 		/// \brief Returns the position in the data stream.
-		/** <p>Returns -1 if the position is unknown.</p>
-			\return The size (-1 if position is unknown)*/
-		int get_position() const;
+		/** <p>Returns SIZE_MAX if the position is unknown.</p>
+			\return The size (SIZE_MAX if position is unknown)*/
+		size_t get_position() const;
 
 		/// \brief Returns true if the input source is in little endian mode.
 		/** \return true if little endian*/
@@ -104,7 +104,7 @@ namespace clan
 			\param len Length to send
 			\param send_all true to send all the data. false = send part of the data, if it would block
 			\return size of data sent*/
-		int send(const void *data, int len, bool send_all = true);
+		size_t send(const void *data, size_t len, bool send_all = true);
 
 		/// \brief Receive data from device.
 		///
@@ -113,14 +113,14 @@ namespace clan
 		/// \param receive_all true to receive all the data. false = receive part of the data, if it would block
 		///
 		/// \return size of data received
-		int receive(void *data, int len, bool receive_all = true);
+		size_t receive(void *data, size_t len, bool receive_all = true);
 
 		/// \brief Peek data from device (data is left in the buffer).
 		///
 		/// \param data Data to receive
 		/// \param len Maximum length of data to receive
 		/// \return size of data received.
-		int peek(void *data, int len);
+		size_t peek(void *data, size_t len);
 
 		/// \brief Seek in data stream.
 		///
@@ -136,7 +136,7 @@ namespace clan
 		/// \param receive_all true to receive all the data. false = receive part of the data, if it would block
 		///
 		/// \return size of data received
-		int read(void *data, int len, bool receive_all = true);
+		size_t read(void *data, size_t len, bool receive_all = true);
 
 		/// \brief Alias for send(data, len, send_all)
 		///
@@ -145,7 +145,7 @@ namespace clan
 		/// \param send_all true to send all the data. false = send part of the data, if it would block
 		///
 		/// \return size of data sent
-		int write(const void *data, int len, bool send_all = true);
+		size_t write(const void *data, size_t len, bool send_all = true);
 
 		/// \brief Changes input data endianess to the local systems mode.
 		void set_system_mode();

--- a/Sources/API/Core/IOData/iodevice_provider.h
+++ b/Sources/API/Core/IOData/iodevice_provider.h
@@ -42,21 +42,21 @@ namespace clan
 		virtual ~IODeviceProvider() { return; }
 
 		/// \brief Returns the size of data stream.
-		/** <p>Returns -1 if the size is unknown.</p>*/
-		virtual int get_size() const { return -1; }
+		/** <p>Returns SIZE_MAX if the size is unknown.</p>*/
+		virtual size_t get_size() const { return size_t(SIZE_MAX); }
 
 		/// \brief Returns the position in the data stream.
-		/** <p>Returns -1 if the position is unknown.</p>*/
-		virtual int get_position() const { return -1; }
+		/** <p>Returns SIZE_MAX if the position is unknown.</p>*/
+		virtual size_t get_position() const { return size_t(SIZE_MAX); }
 
 		/// \brief Send data to device.
-		virtual int send(const void *data, int len, bool send_all = true) = 0;
+		virtual size_t send(const void *data, size_t len, bool send_all = true) = 0;
 
 		/// \brief Receive data from device.
-		virtual int receive(void *data, int len, bool receive_all = true) = 0;
+		virtual size_t receive(void *data, size_t size_t, bool receive_all = true) = 0;
 
 		/// \brief Peek data from device.
-		virtual int peek(void *data, int len) = 0;
+		virtual size_t peek(void *data, size_t size_t) = 0;
 
 		/// \brief Returns a new provider to the same resource.
 		virtual IODeviceProvider *duplicate() = 0;

--- a/Sources/API/Core/System/databuffer.h
+++ b/Sources/API/Core/System/databuffer.h
@@ -43,9 +43,10 @@ namespace clan
 	public:
 		/// \brief Constructs a data buffer of 0 size.
 		DataBuffer();
-		DataBuffer(unsigned int size);
-		DataBuffer(const void *data, unsigned int size);
-		DataBuffer(const DataBuffer &data, unsigned int pos, unsigned int size);
+		DataBuffer(size_t size);
+		DataBuffer(const DataBuffer &copy);
+		DataBuffer(const void *data, size_t size);
+		DataBuffer(const DataBuffer &data, size_t pos, size_t size);
 		~DataBuffer();
 
 		/// \brief Returns a pointer to the data.
@@ -60,16 +61,14 @@ namespace clan
 		const Type *get_data() const { return reinterpret_cast<const Type*>(get_data()); }
 
 		/// \brief Returns the size of the data.
-		unsigned int get_size() const;
+		size_t get_size() const;
 
 		/// \brief Returns the capacity of the data buffer object.
-		unsigned int get_capacity() const;
+		size_t get_capacity() const;
 
 		/// \brief Returns a char in the buffer.
-		char &operator[](int i);
-		const char &operator[](int i) const;
-		char &operator[](unsigned int i);
-		const char &operator[](unsigned int i) const;
+		char &operator[](size_t i);
+		const char &operator[](size_t i) const;
 
 		/// \brief Returns true if the buffer is 0 in size.
 		bool is_null() const;
@@ -77,10 +76,10 @@ namespace clan
 		DataBuffer &operator =(const DataBuffer &copy);
 
 		/// \brief Resize the buffer.
-		void set_size(unsigned int size);
+		void set_size(size_t size);
 
 		/// \brief Preallocate enough memory.
-		void set_capacity(unsigned int capacity);
+		void set_capacity(size_t capacity);
 
 	private:
 		std::shared_ptr<DataBuffer_Impl> impl;

--- a/Sources/Core/IOData/file.cpp
+++ b/Sources/Core/IOData/file.cpp
@@ -39,7 +39,7 @@ namespace clan
 	std::string File::read_text(const std::string &filename)
 	{
 		File file(filename);
-		unsigned int file_size = file.get_size();
+		size_t file_size = file.get_size();
 		std::vector<char> text;
 		text.resize(file_size + 1);
 		text[file_size] = 0;

--- a/Sources/Core/IOData/iodevice.cpp
+++ b/Sources/Core/IOData/iodevice.cpp
@@ -55,14 +55,14 @@ namespace clan
 			throw Exception("IODevice is null");
 	}
 
-	int IODevice::get_size() const
+	size_t IODevice::get_size() const
 	{
 		if (impl)
 			return impl->provider->get_size();
 		return -1;
 	}
 
-	int IODevice::get_position() const
+	size_t IODevice::get_position() const
 	{
 		if (impl)
 			return impl->provider->get_position();
@@ -86,21 +86,21 @@ namespace clan
 		return impl->provider;
 	}
 
-	int IODevice::send(const void *data, int len, bool send_all)
+	size_t IODevice::send(const void *data, size_t len, bool send_all)
 	{
 		if (impl)
 			return impl->provider->send(data, len, send_all);
 		return -1;
 	}
 
-	int IODevice::receive(void *data, int len, bool receive_all)
+	size_t IODevice::receive(void *data, size_t len, bool receive_all)
 	{
 		if (impl)
 			return impl->provider->receive(data, len, receive_all);
 		return -1;
 	}
 
-	int IODevice::peek(void *data, int len)
+	size_t IODevice::peek(void *data, size_t len)
 	{
 		if (impl)
 			return impl->provider->peek(data, len);
@@ -114,12 +114,12 @@ namespace clan
 		return false;
 	}
 
-	int IODevice::read(void *data, int len, bool receive_all)
+	size_t IODevice::read(void *data, size_t len, bool receive_all)
 	{
 		return receive(data, len, receive_all);
 	}
 
-	int IODevice::write(const void *data, int len, bool send_all)
+	size_t IODevice::write(const void *data, size_t len, bool send_all)
 	{
 		return send(data, len, send_all);
 	}
@@ -249,8 +249,8 @@ namespace clan
 
 	void IODevice::write_string_a(const std::string &str)
 	{
-		int size = str.length();
-		write_int32(size);
+		size_t size = str.length();
+		write_int32(int32_t(size));
 		write(str.data(), size);
 	}
 
@@ -406,7 +406,7 @@ namespace clan
 
 	std::string IODevice::read_string_a()
 	{
-		int size = read_int32();
+		size_t size = size_t(read_int32());
 
 		auto str = new char[size];
 		try
@@ -432,13 +432,13 @@ namespace clan
 
 	std::string IODevice::read_string_text(const char *skip_initial_chars, const char *read_until_chars, bool allow_eof)
 	{
-		const int buffer_size = 64;
+		const size_t buffer_size = 64;
 		char buffer[buffer_size];
-		int read_size;
-		int size = 0;
+		size_t read_size;
+		size_t size = 0;
 		bool find_flag = true;
 		bool null_found = false;
-		int current_position = get_position();
+		size_t current_position = get_position();
 
 		// Skip initial unwanted chars
 		if (skip_initial_chars)
@@ -448,7 +448,7 @@ namespace clan
 				read_size = receive(buffer, buffer_size, true);
 
 				char *dptr = buffer;
-				for (int cnt = 0; cnt < read_size; cnt++, dptr++)	// Search the buffer
+				for (size_t cnt = 0; cnt != read_size; ++cnt, dptr++)	// Search the buffer
 				{
 					char letter = *dptr;
 					bool match_flag = false;
@@ -478,7 +478,7 @@ namespace clan
 				}
 			}
 
-			seek(current_position, seek_set);	// Set new position
+			seek(int(current_position), seek_set);	// Set new position
 		}
 
 		find_flag = true;
@@ -488,7 +488,7 @@ namespace clan
 		{
 			read_size = receive(buffer, buffer_size, true);
 			char *dptr = buffer;
-			for (int cnt = 0; cnt < read_size; cnt++, dptr++)
+			for (size_t cnt = 0; cnt != read_size; ++cnt, dptr++)
 			{
 				char letter = *dptr;
 				// Treat NUL as a special terminating character
@@ -528,7 +528,7 @@ namespace clan
 				break;
 			}
 		}
-		seek(current_position, seek_set);
+		seek(int(current_position), seek_set);
 
 		// Read the string, now that we know its length
 

--- a/Sources/Core/IOData/iodevice_provider_file.h
+++ b/Sources/Core/IOData/iodevice_provider_file.h
@@ -40,44 +40,44 @@ namespace clan
 		IODeviceProvider_File();
 
 		IODeviceProvider_File(
-			const std::string &filename,
-			File::OpenMode mode,
-			unsigned int access,
-			unsigned int share,
-			unsigned int flags);
+			const std::string &a_filename,
+			File::OpenMode a_mode,
+			unsigned int a_access,
+			unsigned int a_share,
+			unsigned int a_flags);
 
 		~IODeviceProvider_File();
 
-		int get_size() const override;
-		int get_position() const override;
+		size_t get_size() const override;
+		size_t get_position() const override;
 
 		bool open(
-			const std::string &filename,
-			File::OpenMode mode,
-			unsigned int access,
-			unsigned int share,
-			unsigned int flags);
+			const std::string &a_filename,
+			File::OpenMode a_mode,
+			unsigned int a_access,
+			unsigned int a_share,
+			unsigned int a_flags);
 
 		void close();
 
-		int read(void *buffer, int size, bool read_all);
-		int write(const void *buffer, int size, bool write_all);
-		int send(const void *data, int len, bool send_all) override;
-		int receive(void *data, int len, bool receive_all) override;
-		int peek(void *data, int len) override;
+		size_t read(void *buffer, size_t size, bool read_all);
+		size_t write(const void *buffer, size_t size, bool write_all);
+		size_t send(const void *data, size_t len, bool send_all) override;
+		size_t receive(void *data, size_t len, bool receive_all) override;
+		size_t peek(void *data, size_t len) override;
 
 		bool seek(int position, IODevice::SeekMode mode) override;
 
 		IODeviceProvider *duplicate() override;
 
 	private:
-		int lowlevel_read(void *buffer, int size, bool read_all);
+		size_t lowlevel_read(void *buffer, size_t size, bool read_all);
 
 		std::string filename;
-		File::OpenMode open_mode;
-		unsigned int access;
-		unsigned int share;
-		unsigned int flags;
+		File::OpenMode open_mode = File::OpenMode::open_always;
+		unsigned int access = 0;
+		unsigned int share = 0;
+		unsigned int flags = 0;
 
 #ifdef WIN32
 		HANDLE handle;

--- a/Sources/Core/IOData/iodevice_provider_memory.cpp
+++ b/Sources/Core/IOData/iodevice_provider_memory.cpp
@@ -43,12 +43,12 @@ namespace clan
 	{
 	}
 
-	int IODeviceProvider_Memory::get_size() const
+	size_t IODeviceProvider_Memory::get_size() const
 	{
 		return data.get_size();
 	}
 
-	int IODeviceProvider_Memory::get_position() const
+	size_t IODeviceProvider_Memory::get_position() const
 	{
 		validate_position();
 		return position;
@@ -64,10 +64,10 @@ namespace clan
 		return data;
 	}
 
-	int IODeviceProvider_Memory::send(const void *send_data, int len, bool send_all)
+	size_t IODeviceProvider_Memory::send(const void *send_data, size_t len, bool send_all)
 	{
 		validate_position();
-		int size_needed = position + len;
+		size_t size_needed = position + len;
 		if (size_needed > data.get_size())
 		{
 			if (size_needed > data.get_capacity())	// Capacity exceeded
@@ -83,10 +83,10 @@ namespace clan
 		return len;
 	}
 
-	int IODeviceProvider_Memory::receive(void *recv_data, int len, bool receive_all)
+	size_t IODeviceProvider_Memory::receive(void *recv_data, size_t len, bool receive_all)
 	{
 		validate_position();
-		int data_available = data.get_size() - position;
+		size_t data_available = data.get_size() - position;
 		if (len > data_available)
 			len = data_available;
 		memcpy(recv_data, data.get_data() + position, len);
@@ -94,10 +94,10 @@ namespace clan
 		return len;
 	}
 
-	int IODeviceProvider_Memory::peek(void *recv_data, int len)
+	size_t IODeviceProvider_Memory::peek(void *recv_data, size_t len)
 	{
 		validate_position();
-		int data_available = data.get_size() - position;
+		size_t data_available = data.get_size() - position;
 		if (len > data_available)
 			len = data_available;
 		memcpy(recv_data, data.get_data() + position, len);
@@ -107,7 +107,7 @@ namespace clan
 	bool IODeviceProvider_Memory::seek(int requested_position, IODevice::SeekMode mode)
 	{
 		validate_position();
-		int new_position = position;
+		int new_position = int(position);
 		switch (mode)
 		{
 		case IODevice::seek_set:
@@ -117,15 +117,15 @@ namespace clan
 			new_position += requested_position;
 			break;
 		case IODevice::seek_end:
-			new_position = data.get_size() + requested_position;
+			new_position = int(data.get_size()) + requested_position;
 			break;
 		default:
 			return false;
 		}
 
-		if (new_position >= 0 && new_position <= data.get_size())
+		if (new_position >= 0 && new_position <= int(data.get_size()))
 		{
-			position = new_position;
+			position = size_t(new_position);
 			return true;
 		}
 		else
@@ -141,9 +141,7 @@ namespace clan
 
 	void IODeviceProvider_Memory::validate_position() const
 	{
-		if (position < 0)
-			position = 0;
-		else if (position > data.get_size())
+		if (position > data.get_size())
 			position = data.get_size();
 	}
 }

--- a/Sources/Core/IOData/iodevice_provider_memory.h
+++ b/Sources/Core/IOData/iodevice_provider_memory.h
@@ -39,15 +39,15 @@ namespace clan
 		IODeviceProvider_Memory();
 		IODeviceProvider_Memory(DataBuffer &data);
 
-		virtual int get_size() const override;
-		virtual int get_position() const override;
+		virtual size_t get_size() const override;
+		virtual size_t get_position() const override;
 
 		const DataBuffer &get_data() const;
 		DataBuffer &get_data();
 
-		virtual int send(const void *data, int len, bool send_all = true) override;
-		virtual int receive(void *data, int len, bool receive_all = true) override;
-		virtual int peek(void *data, int len) override;
+		virtual size_t send(const void *data, size_t len, bool send_all = true) override;
+		virtual size_t receive(void *data, size_t len, bool receive_all = true) override;
+		virtual size_t peek(void *data, size_t len) override;
 		virtual bool seek(int position, IODevice::SeekMode mode) override;
 		IODeviceProvider *duplicate() override;
 
@@ -55,6 +55,6 @@ namespace clan
 		void validate_position() const;
 
 		DataBuffer data;
-		mutable int position;
+		mutable size_t position;
 	};
 }

--- a/Sources/Core/System/databuffer.cpp
+++ b/Sources/Core/System/databuffer.cpp
@@ -46,8 +46,8 @@ namespace clan
 
 	public:
 		char *data;
-		unsigned int size;
-		unsigned int allocated_size;
+		size_t size;
+		size_t allocated_size;
 	};
 
 	DataBuffer::DataBuffer()
@@ -55,20 +55,26 @@ namespace clan
 	{
 	}
 
-	DataBuffer::DataBuffer(unsigned int new_size)
+	DataBuffer::DataBuffer(size_t new_size)
 		: impl(std::make_shared<DataBuffer_Impl>())
 	{
 		set_size(new_size);
 	}
 
-	DataBuffer::DataBuffer(const void *new_data, unsigned int new_size)
+	DataBuffer::DataBuffer(const DataBuffer &copy)
+		: impl(copy.impl)
+	{
+		// Explicitly declared constructor like operator =
+	}
+
+	DataBuffer::DataBuffer(const void *new_data, size_t new_size)
 		: impl(std::make_shared<DataBuffer_Impl>())
 	{
 		set_size(new_size);
 		memcpy(impl->data, new_data, new_size);
 	}
 
-	DataBuffer::DataBuffer(const DataBuffer &new_data, unsigned int pos, unsigned int size)
+	DataBuffer::DataBuffer(const DataBuffer &new_data, size_t pos, size_t size)
 		: impl(std::make_shared<DataBuffer_Impl>())
 	{
 		set_size(size);
@@ -99,22 +105,12 @@ namespace clan
 		return impl->allocated_size;
 	}
 
-	char &DataBuffer::operator[](int i)
+	char &DataBuffer::operator[](size_t i)
 	{
 		return impl->data[i];
 	}
 
-	const char &DataBuffer::operator[](int i) const
-	{
-		return impl->data[i];
-	}
-
-	char &DataBuffer::operator[](unsigned int i)
-	{
-		return impl->data[i];
-	}
-
-	const char &DataBuffer::operator[](unsigned int i) const
+	const char &DataBuffer::operator[](size_t i) const
 	{
 		return impl->data[i];
 	}
@@ -125,7 +121,7 @@ namespace clan
 		return *this;
 	}
 
-	void DataBuffer::set_size(unsigned int new_size)
+	void DataBuffer::set_size(size_t new_size)
 	{
 		if (new_size > impl->allocated_size)
 		{
@@ -143,7 +139,7 @@ namespace clan
 		}
 	}
 
-	void DataBuffer::set_capacity(unsigned int new_capacity)
+	void DataBuffer::set_capacity(size_t new_capacity)
 	{
 		if (new_capacity > impl->allocated_size)
 		{

--- a/Sources/Core/Zip/zip_iodevice_fileentry.h
+++ b/Sources/Core/Zip/zip_iodevice_fileentry.h
@@ -43,12 +43,12 @@ namespace clan
 		ZipIODevice_FileEntry(IODevice iodevice, const ZipFileEntry &entry);
 		~ZipIODevice_FileEntry();
 
-		virtual int get_size() const override;
-		virtual int get_position() const override;
+		virtual size_t get_size() const override;
+		virtual size_t get_position() const override;
 
-		virtual int send(const void *data, int len, bool send_all) override;
-		virtual int receive(void *data, int len, bool receive_all) override;
-		virtual int peek(void *data, int len) override;
+		virtual size_t send(const void *data, size_t len, bool send_all) override;
+		virtual size_t receive(void *data, size_t len, bool receive_all) override;
+		virtual size_t peek(void *data, size_t len) override;
 
 		virtual bool seek(int position, IODevice::SeekMode mode) override;
 
@@ -57,7 +57,7 @@ namespace clan
 	private:
 		void init();
 		void deinit();
-		int lowlevel_read(void *buffer, int size, bool read_all);
+		size_t lowlevel_read(void *buffer, size_t size, bool read_all);
 
 		IODevice iodevice;
 		ZipFileEntry file_entry;


### PR DESCRIPTION
### Report Issue #97

I started with `IODevice.cpp` and remade from `int` to `size_t` all the related files. Into subsection `core/zip` did not dive, limited to cosmetics at the interface level. Although there is an unsafe code, for example - forced conversion from `int64_t` to `int`:
```
     int64_t pos;
     ...
     int ZipIODevice_FileEntry::get_position() const
	{
		return (int)pos;
	}

```
I do not use zip and will not be able to test its performance. At least it became no worse.

Also did not touch the `seek` functions. Their change is non-trivial and requires separate testing and experience of WinAPI (and others OS). As result - and early and now it is impossible to move the pointer in the file more than 2^31 bytes.

Further, thanks to the code analyzer (PVS) was convinced that it had not added any new problems, and also slightly improved the existing code in the changed files to exclude the following warnings:

* V676. It is incorrect to compare the variable of BOOL type with TRUE.
https://www.viva64.com/en/w/v676/print/

* V688. The 'foo' local variable possesses the same name as one of the class members, which can result in a confusion.
https://www.viva64.com/en/w/v688/print/

* V690. The class implements a copy constructor/operator=, but lacks the operator=/copy constructor.
https://www.viva64.com/en/w/v690/print/

* V730. Not all members of a class are initialized inside the constructor.
https://www.viva64.com/en/w/v730/print/

In conclusion, compiled all the examples (45/47 successful, 2 - I have no "assimp/cimport.h" for Object3D and Quaternion) and made sure that they did not crush. The examples "Layered Window" and "Layered Window 2" crashes with `OpenGL INVALID_ENUM` but it had chashed before my changes too. And finally test my own project, which actively uses `file.read()` and `write()`. No problems detected.