### PR TITLE
Refactor DirectoryScanner_Unix::scan

### DIFF
--- a/Sources/Core/IOData/Unix/directory_scanner_unix.cpp
+++ b/Sources/Core/IOData/Unix/directory_scanner_unix.cpp
@@ -45,10 +45,9 @@ DirectoryScanner_Unix::DirectoryScanner_Unix ()
 {
 }
 
-bool DirectoryScanner_Unix::scan (const std::string& arg_path_name)
+bool DirectoryScanner_Unix::doscan (const std::string& arg_path_name)
 {
 	path_name   = arg_path_name;
-	use_pattern = false;
 
 	if (path_name.empty ())
 	  path_name = ".";
@@ -63,24 +62,18 @@ bool DirectoryScanner_Unix::scan (const std::string& arg_path_name)
 		return true;
 }
 
+bool DirectoryScanner_Unix::scan (const std::string& arg_path_name)
+{
+	use_pattern = false;
+	return doscan(arg_path_name);
+}
+
 bool DirectoryScanner_Unix::scan (const std::string& arg_path_name, 
 				     const std::string& arg_file_pattern)
 {
-	path_name    = arg_path_name;
 	file_pattern = arg_file_pattern;
 	use_pattern  = true;
-
-	if (path_name.empty ())
-	  path_name = ".";
-
-	if(dir_temp)
-		closedir(dir_temp);
-
-	dir_temp = opendir(path_name.c_str());
-	if (dir_temp == nullptr)
-		return false;
-	else
-		return true;
+	return doscan(arg_path_name);
 }
 
 DirectoryScanner_Unix::~DirectoryScanner_Unix()

--- a/Sources/Core/IOData/Unix/directory_scanner_unix.h
+++ b/Sources/Core/IOData/Unix/directory_scanner_unix.h
@@ -102,6 +102,8 @@ private:
 	std::string path_name;
 
 	std::string file_pattern;
+
+	bool doscan (const std::string& pathname);
 /// \}
 };
 


### PR DESCRIPTION
Refactor DirectoryScanner_Unix::scan
to reduce code duplication

This is going to serve as a base for reworking the `next` method
to not vary from filesystem readdir order.

Note: only slightly tested.

This PR was done while working on reproducible builds for openSUSE.