### PR TITLE
Fix shaders in Display_Shaders examples to compile

### DIFF
--- a/Examples/Display_Shaders/Bloom/Resources/bloom_fs.glsl
+++ b/Examples/Display_Shaders/Bloom/Resources/bloom_fs.glsl
@@ -1,3 +1,5 @@
+#version 150
+
 uniform sampler2D BaseTexture;
 uniform float BaseIntensity;
 uniform float BaseSaturation;
@@ -5,7 +7,8 @@ uniform float BaseSaturation;
 uniform sampler2D BloomTexture;
 uniform float BloomIntensity;
 uniform float BloomSaturation;
-varying vec2 TexCoord;
+out vec2 TexCoord;
+out vec4 fragColor;
 
 vec4 AdjustSaturation(in vec4 color, in float saturation)
 {
@@ -17,10 +20,10 @@ vec4 AdjustSaturation(in vec4 color, in float saturation)
 
 vec4 BloomCombine()
 {
-    vec4 bloom = texture2D(BloomTexture, TexCoord);
+    vec4 bloom = texture(BloomTexture, TexCoord);
     bloom = (AdjustSaturation(bloom, BloomSaturation) * BloomIntensity);
 
-    vec4 base = texture2D(BaseTexture, TexCoord);
+    vec4 base = texture(BaseTexture, TexCoord);
     base = (AdjustSaturation(base, BaseSaturation) * BaseIntensity);
     
     base *= (1.0 - clamp(bloom, 0.0, 1.0));
@@ -30,5 +33,5 @@ vec4 BloomCombine()
 
 void main() 
 {
-    gl_FragColor = BloomCombine();
+    fragColor = BloomCombine();
 }

--- a/Examples/Display_Shaders/Bloom/Resources/bloom_vs.glsl
+++ b/Examples/Display_Shaders/Bloom/Resources/bloom_vs.glsl
@@ -1,8 +1,10 @@
-attribute vec4 Position;
-attribute vec2 TexCoord0;
+#version 150
+
+in vec4 Position;
+in vec2 TexCoord0;
 uniform mat4 cl_ModelViewProjectionMatrix;
 
-varying vec2 TexCoord;
+out vec2 TexCoord;
 
 void main(void) 
 { 

--- a/Examples/Display_Shaders/Bloom/Resources/gaussian_fs.glsl
+++ b/Examples/Display_Shaders/Bloom/Resources/gaussian_fs.glsl
@@ -15,7 +15,7 @@ vec4 GaussianBlur()
 	vec4 c = vec4(0.0);
 	for (int i = 0 ; i < 15; i++)
 	{
-		c += texture2D(SourceTexture, (TexCoord + Sample[i].xy)) * Sample[i].z;
+		c += texture(SourceTexture, (TexCoord + Sample[i].xy)) * Sample[i].z;
 	}
 
 	return c;

--- a/Examples/Display_Shaders/Bloom/Resources/highlights_fs.glsl
+++ b/Examples/Display_Shaders/Bloom/Resources/highlights_fs.glsl
@@ -1,14 +1,17 @@
+#version 150
+
 uniform sampler2D SourceTexture;
 uniform float Threshold;
-varying vec2 TexCoord;
+out vec2 TexCoord;
+out vec4 fragColor;
 
 vec4 ExtractHighlights()
 {
-	vec4 c = texture2D(SourceTexture, TexCoord);
+	vec4 c = texture(SourceTexture, TexCoord);
     return clamp((c - Threshold) / (1.0 - Threshold), 0.0, 1.0);
 }
 
 void main() 
 {
-    gl_FragColor = ExtractHighlights();
+    fragColor = ExtractHighlights();
 }

--- a/Examples/Display_Shaders/Bloom/Resources/highlights_vs.glsl
+++ b/Examples/Display_Shaders/Bloom/Resources/highlights_vs.glsl
@@ -1,8 +1,10 @@
-attribute vec4 Position;
-attribute vec2 TexCoord0;
+#version 150
+
+in  vec4 Position;
+in vec2 TexCoord0;
 uniform mat4 cl_ModelViewProjectionMatrix;
 
-varying vec2 TexCoord;
+out vec2 TexCoord;
 
 void main(void) 
 { 

--- a/Examples/Display_Shaders/Gaussian/Resources/fragment_shader.glsl
+++ b/Examples/Display_Shaders/Gaussian/Resources/fragment_shader.glsl
@@ -15,7 +15,7 @@ vec4 GaussianBlur()
 	vec4 c = vec4(0.0);
 	for (int i = 0 ; i < 15; i++)
 	{
-		c += texture2D(SourceTexture, (TexCoord + Sample[i].xy)) * Sample[i].z;
+		c += texture(SourceTexture, (TexCoord + Sample[i].xy)) * Sample[i].z;
 	}
 
 	return c;

--- a/Examples/Display_Shaders/HSVSprite/Resources/fragment.glsl
+++ b/Examples/Display_Shaders/HSVSprite/Resources/fragment.glsl
@@ -1,3 +1,4 @@
+#version 150
 
 uniform sampler2D Texture0;
 varying float HueOffset;

--- a/Examples/Display_Shaders/HSVSprite/Resources/vertex.glsl
+++ b/Examples/Display_Shaders/HSVSprite/Resources/vertex.glsl
@@ -1,9 +1,10 @@
+#version 150
 
-attribute vec4 Position;
-attribute float HueOffset0;
-attribute vec2 TexCoord0;
-varying float HueOffset;
-varying vec2 TexCoord;
+in vec4 Position;
+in float HueOffset0;
+in vec2 TexCoord0;
+out float HueOffset;
+out vec2 TexCoord;
 
 void main(void)
 {

--- a/Examples/Display_Shaders/NightVision/Resources/fragment_shader.glsl
+++ b/Examples/Display_Shaders/NightVision/Resources/fragment_shader.glsl
@@ -24,9 +24,9 @@ void main ()
 		vec2 uv;
 		uv.x = 0.4*sin(elapsedTime*50.0);
 		uv.y = 0.4*cos(elapsedTime*50.0);
-		float m = texture2D(maskTex, TexCoord).r;
-		vec3 n = texture2D(noiseTex, (TexCoord*3.5) + uv).rgb;
-		vec3 c = texture2D(sceneBuffer, TexCoord + (n.xy*0.005)).rgb;
+		float m = texture(maskTex, TexCoord).r;
+		vec3 n = texture(noiseTex, (TexCoord*3.5) + uv).rgb;
+		vec3 c = texture(sceneBuffer, TexCoord + (n.xy*0.005)).rgb;
 
 		float lum = dot(vec3(0.30, 0.59, 0.11), c);
 
@@ -38,7 +38,7 @@ void main ()
 	}
 	else
 	{
-		finalColor = texture2D(sceneBuffer,
+		finalColor = texture(sceneBuffer,
 		TexCoord);
 	}
 

--- a/Examples/Display_Shaders/PostProcessing/Resources/fragment_shader.glsl
+++ b/Examples/Display_Shaders/PostProcessing/Resources/fragment_shader.glsl
@@ -24,7 +24,7 @@ vec4 noise()
     x = (mod(x, 13.0) * mod(x, 123.0));
     float dx = mod(x, 0.0015) * Amount;
     float dy = mod(x, 0.0005) * Amount;
-    vec4 c = texture2D(Texture, (TexCoord + vec2(dx, dy)));
+    vec4 c = texture(Texture, (TexCoord + vec2(dx, dy)));
     return c;
 }
 
@@ -39,5 +39,5 @@ vec4 grey(in vec4 fragment)
 void main() 
 {
 	cl_FragColor = grey(scanlines(noise()));
-//	cl_FragColor = grey(scanlines(texture2D(Texture, TexCoord)));
+//	cl_FragColor = grey(scanlines(texture(Texture, TexCoord)));
 }

--- a/Examples/Display_Shaders/Shockwave/Resources/fragment_shader.glsl
+++ b/Examples/Display_Shaders/Shockwave/Resources/fragment_shader.glsl
@@ -29,7 +29,7 @@ void main()
 		vec2 diffUV = normalize(uv - center);
 		texture_coord = uv + (diffUV * diffTime);
 
-		cl_FragColor = texture2D(Texture0, texture_coord);
+		cl_FragColor = texture(Texture0, texture_coord);
 
 		cl_FragColor.r += powDiff * glow;
 		cl_FragColor.g += powDiff * glow;
@@ -37,6 +37,6 @@ void main()
 
 	}
 	else
-		cl_FragColor = texture2D(Texture0, texture_coord);
+		cl_FragColor = texture(Texture0, texture_coord);
 
 }


### PR DESCRIPTION
**Fixed bug description**

I met errors during compilation shader like:
`libc++abi.dylib: terminating with uncaught exception of type clan::Exception: Unable to compile shader program fragment_shader.glsl: ERROR: 0:27: Invalid call of undeclared identifier 'texture2D'`

`libc++abi.dylib: terminating with uncaught exception of type clan::Exception: Unable to compile shader program vertex.glsl: ERROR: 0:2: '' :  #version required and missing.
ERROR: 0:2: 'attribute' : syntax error: syntax error`

**How to reproduce**

I wrote bash script build.sh to build example.
`g++ -std=c++11 -o $1 Sources/*.cpp -Xlinker -v -L../../../Build/lib/osx -lpthread -lclanApp -lclanCore -lclanGL -lclanDisplay -lclanUI -I../../../Build/include -framework OpenGL -framework Cocoa`

Command ./build.sh PostProcessing in folder example makes the executable file. Launch ./PostProcessing and you will get compilation error messages for shaders.